### PR TITLE
Populate column types in dbt docs

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -129,9 +129,9 @@ jobs:
           W
           EOF
 
-          tpareset –y Enable QVCI
+          tpareset –y QVCI
           "
-          
+
           $GITHUB_WORKSPACE/.github/workflows/scripts/verifyVantageIsRunning.sh
 
           cd $GITHUB_WORKSPACE/test/catalog/with_qvci

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -72,30 +72,7 @@ jobs:
 
       - name: Verify Vantage Express is running
         shell: bash
-        run: |
-          # add bteq to path
-          export PATH=$PATH:"/Users/runner/Library/Application Support/teradata/client/17.10/bin/"
-
-          # prepare bteq test script
-          cat << EOF > /tmp/test.bteq
-          .SET EXITONDELAY ON MAXREQTIME 20
-          .logon 127.0.0.1/dbc,dbc
-          select current_time;
-          .logoff
-          EOF
-
-          n=1
-          until [ "$n" -ge 10 ]
-          do
-            echo "Trying to connect to Vantage Express. Attempt $n. This might take a minute."
-            bteq < /tmp/test.bteq && break
-            n=$((n+1))
-            sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tail -200 /var/log/messages' || true
-            echo "Waiting 10 seconds before the next attempt."
-            sleep 10
-          done
-
-
+        run: ./github/workflows/scripts/verifyVantageIsRunning.sh
       - name: Run pytest tests
         run: pytest test/integration/teradata-17.10.dbtspec
       - name: Run pytest tests with existing database
@@ -146,6 +123,16 @@ jobs:
           ./run.sh
       - name: Run catalog tests
         run: |
+          # set DisableQVCI to false - this will give us data type info for views in DBC.ColumnsJQV
+          dbscontrol << EOF
+          M internal 551=false
+          W
+          EOF
+
+          # we now need to restart to apply the setting
+          sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tpareset –y Enable QVCI'
+          $GITHUB_WORKSPACE/github/workflows/scripts/verifyVantageIsRunning.sh
+
           cd $GITHUB_WORKSPACE/test/catalog/with_qvci
           ./run.sh
           cd $GITHUB_WORKSPACE/test/catalog/without_qvci

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -145,7 +145,7 @@ jobs:
           cd $GITHUB_WORKSPACE/test/performance
           ./run.sh
       - name: Run catalog tests
-        run |
+        run: |
           cd $GITHUB_WORKSPACE/test/catalog/with_qvci
           ./run.sh
           cd $GITHUB_WORKSPACE/test/catalog/without_qvci

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -128,10 +128,10 @@ jobs:
           M internal 551=false
           W
           EOF
-          ""
 
-          # we now need to restart to apply the setting
-          sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tpareset –y Enable QVCI'
+          tpareset –y Enable QVCI
+          "
+          
           $GITHUB_WORKSPACE/.github/workflows/scripts/verifyVantageIsRunning.sh
 
           cd $GITHUB_WORKSPACE/test/catalog/with_qvci

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -68,7 +68,7 @@ jobs:
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=yes
           export HOMEBREW_NO_INSTALL_CLEANUP=yes
           export HOMEBREW_NO_INSTALL_UPGRADE=yes
-          brew install coreutils
+          brew install coreutils jq
 
       - name: Verify Vantage Express is running
         shell: bash
@@ -129,9 +129,26 @@ jobs:
                 timeout_seconds: 300
                 priority: interactive
                 retries: 1
-            target: dbt_perf_test
+              dbt_catalog_test:
+                type: teradata
+                host: localhost
+                user: dbc
+                password: dbc
+                logmech: TD2
+                schema: dbt_catalog_test
+                tmode: ANSI
+                threads: 1
+                timeout_seconds: 300
+                priority: interactive
+                retries: 1
           EOF
-          cd test/performance
+          cd $GITHUB_WORKSPACE/test/performance
+          ./run.sh
+      - name: Run catalog tests
+        run |
+          cd $GITHUB_WORKSPACE/test/catalog/with_qvci
+          ./run.sh
+          cd $GITHUB_WORKSPACE/test/catalog/without_qvci
           ./run.sh
       - uses: actions/upload-artifact@v2
         if: ${{ failure() ||  cancelled() }}

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Verify Vantage Express is running
         shell: bash
-        run: ./github/workflows/scripts/verifyVantageIsRunning.sh
+        run: ./.github/workflows/scripts/verifyVantageIsRunning.sh
       - name: Run pytest tests
         run: pytest test/integration/teradata-17.10.dbtspec
       - name: Run pytest tests with existing database

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -131,7 +131,7 @@ jobs:
 
           # we now need to restart to apply the setting
           sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tpareset –y Enable QVCI'
-          $GITHUB_WORKSPACE/github/workflows/scripts/verifyVantageIsRunning.sh
+          $GITHUB_WORKSPACE/.github/workflows/scripts/verifyVantageIsRunning.sh
 
           cd $GITHUB_WORKSPACE/test/catalog/with_qvci
           ./run.sh

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -129,7 +129,7 @@ jobs:
           W
           EOF
 
-          tpareset –y QVCI
+          tpareset -y Enable QVCI
           "
 
           $GITHUB_WORKSPACE/.github/workflows/scripts/verifyVantageIsRunning.sh

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -124,10 +124,11 @@ jobs:
       - name: Run catalog tests
         run: |
           # set DisableQVCI to false - this will give us data type info for views in DBC.ColumnsJQV
-          dbscontrol << EOF
+          sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost  "dbscontrol << EOF
           M internal 551=false
           W
           EOF
+          ""
 
           # we now need to restart to apply the setting
           sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tpareset –y Enable QVCI'

--- a/.github/workflows/scripts/verifyVantageIsRunning.sh
+++ b/.github/workflows/scripts/verifyVantageIsRunning.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# add bteq to path
+export PATH=$PATH:"/Users/runner/Library/Application Support/teradata/client/17.10/bin/"
+
+# prepare bteq test script
+cat << EOF > /tmp/test.bteq
+.SET EXITONDELAY ON MAXREQTIME 20
+.logon 127.0.0.1/dbc,dbc
+select current_time;
+.logoff
+EOF
+
+n=1
+until [ "$n" -ge 10 ]
+do
+  echo "Trying to connect to Vantage Express. Attempt $n. This might take a minute."
+  bteq < /tmp/test.bteq && break
+  n=$((n+1))
+  sshpass -p root ssh -o StrictHostKeyChecking=no -p 4422 root@localhost 'tail -200 /var/log/messages' || true
+  echo "Waiting 10 seconds before the next attempt."
+  sleep 10
+done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ### Features
 
 ### Fixes
-* Resolved [dbt seed fails when target table already exists](https://github.com/Teradata/dbt-teradata/issues/6)
-* Resolved [Docs generate is failing when a project contains a source](https://github.com/Teradata/dbt-teradata/issues/3)
+* Resolved [Populate column types in dbt docs](https://github.com/Teradata/dbt-teradata/issues/4)
 ### Docs
 
 ### Under the hood
+* Added automated tests for catalog generation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## dbt-teradata 0.19.0a
 
 ### Features
-
+* When the adapter is not able to detect a column type, it will return `N/A` instead of defaulting to `CHARACTER`.
 ### Fixes
 * Resolved [Populate column types in dbt docs](https://github.com/Teradata/dbt-teradata/issues/4)
 ### Docs
 
 ### Under the hood
 * Added automated tests for catalog generation.
-

--- a/README.md
+++ b/README.md
@@ -94,6 +94,27 @@ All dbt commands are supported.
 
 ### Custom configurations
 
+#### General
+
+* *Enable view column types in docs* -  Teradata Vantage has a dbscontrol configuration flag called `DisableQVCI`. This flag instructs the database to create `DBC.ColumnsJQV` with view column type definitions. To enable this functionality you need to:
+  1. Enable QVCI mode in Vantage. Use `dbscontrol` utility and then restart Teradata. Run these commands as a privileged user on a Teradata node:
+      ```bash
+      # option 551 is DisableQVCI. Setting it to false enables QVCI.
+      dbscontrol << EOF
+      M internal 551=false
+      W
+      EOF
+
+      # restart Teradata
+      tpareset –y Enable QVCI
+      ```
+  2. Instruct `dbt` to use `QVCI` mode. Include the following variable in your `dbt_project.yml`:
+      ```yaml
+      vars:
+        use_qvci: true
+      ```
+      For example configuration, see `test/catalog/with_qvci/dbt_project.yml`.
+
 #### Seeds
 
 * `use_fastload` configuration will instruct the plugin to use [fastload](https://github.com/Teradata/python-driver#FastLoad) when handling `dbt seed` command. You can set this seed configuration option in your `project.yml` file, e.g.:

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -53,7 +53,7 @@
 {% endmacro %}
 
 {% macro teradata__current_timestamp() -%}
-  current_timestamp
+  current_timestamp(6)
 {%- endmacro %}
 
 {% macro teradata__rename_relation(from_relation, to_relation) -%}

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -53,7 +53,7 @@
 {% endmacro %}
 
 {% macro teradata__current_timestamp() -%}
-  current_timestamp(6)
+  CURRENT_TIMESTAMP (FORMAT 'YYYY-MM-DD HH:MI:SS.S(F)Z')
 {%- endmacro %}
 
 {% macro teradata__rename_relation(from_relation, to_relation) -%}

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -76,6 +76,8 @@
 {% endmacro %}
 
 {% macro teradata__get_columns_in_relation(relation) -%}
+    {% set use_qvci = var("use_qvci", "false") | as_bool %}
+     {{ log("use_qvci set to : " ~ use_qvci) }}
     {% call statement('get_columns_in_relation', fetch_result=True) %}
     select
       ColumnsV.ColumnName as "column",
@@ -124,7 +126,7 @@
         when ColumnsV.ColumnType = 'SZ' then 'TIMESTAMP WITH TIME ZONE'
         when ColumnsV.ColumnType = 'UT' then 'USER‑DEFINED TYPE'
         when ColumnsV.ColumnType = 'XM' then 'XML'
-        else 'CHARACTER'
+        else 'N/A'
       end as dtype,
       case
         when ColumnsV.CharType = 1 then ColumnsV.ColumnLength
@@ -139,14 +141,19 @@
         else TablesV.TableKind
       end as table_type,
       ColumnsV.ColumnID as column_index
-    from DBC.ColumnsV
+    from
+    {% if use_qvci == True -%}
+      DBC.ColumnsJQV as ColumnsV
+    {% else %}
+      DBC.ColumnsV
+    {%- endif %}
     left outer join DBC.TablesV
       on ColumnsV.DatabaseName = TablesV.DatabaseName
       and ColumnsV.TableName = TablesV.TableName
     where
       TablesV.TableKind in ('T', 'V')
-      and ColumnsV.DatabaseName like '{{ relation.schema }}'
-      and ColumnsV.TableName like '{{ relation.identifier }}'
+      and ColumnsV.DatabaseName = '{{ relation.schema }}' (NOT CASESPECIFIC)
+      and ColumnsV.TableName = '{{ relation.identifier }}' (NOT CASESPECIFIC)
     order by
       ColumnsV.ColumnID
     {% endcall %}

--- a/test/catalog/with_qvci/.gitignore
+++ b/test/catalog/with_qvci/.gitignore
@@ -1,4 +1,3 @@
 logs/
 target/
 dbt_modules/
-sampledata.csv

--- a/test/catalog/with_qvci/data/test_table.csv
+++ b/test/catalog/with_qvci/data/test_table.csv
@@ -1,0 +1,3 @@
+animal, superpower, magic_index
+unicorn, magic, 100
+pegasus, flying, 500

--- a/test/catalog/with_qvci/dbt_project.yml
+++ b/test/catalog/with_qvci/dbt_project.yml
@@ -1,0 +1,45 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'teradata'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'teradata'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_modules"
+
+#on-run-start:
+#  - "{{ install_dbt_drop_relation_if_exists() }}"
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  teradata:
+    +materialized: view
+
+vars:
+  use_qvci: true
+
+seeds:
+  teradata:
+    +use_fastload: true

--- a/test/catalog/with_qvci/models/sources.yml
+++ b/test/catalog/with_qvci/models/sources.yml
@@ -1,0 +1,7 @@
+version: 2
+sources:
+  - name: alias_source_schema
+    schema: dbt_catalog_test
+    tables:
+      - name: alias_source_table
+        identifier: test_table

--- a/test/catalog/with_qvci/models/table_from_source.sql
+++ b/test/catalog/with_qvci/models/table_from_source.sql
@@ -1,0 +1,6 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}

--- a/test/catalog/with_qvci/models/view_from_source.sql
+++ b/test/catalog/with_qvci/models/view_from_source.sql
@@ -1,0 +1,6 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}

--- a/test/catalog/with_qvci/run.sh
+++ b/test/catalog/with_qvci/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+dbt -d seed --target dbt_catalog_test
+dbt -d run --target dbt_catalog_test
+dbt -d docs generate --target dbt_catalog_test
+
+
+assertJsonElementEquals() {
+  VALUE_IN_JSON=`cat target/catalog.json| jq -r $2`
+  if [ "$1" == "$VALUE_IN_JSON" ]; then
+    echo "Assert successful for '$1' and '$2'"
+    return
+  else
+    echo "Assert failed for $2. Was $VALUE_IN_JSON but expected $1"
+    exit 1
+  fi
+}
+
+# assert on target/catalog.json
+assertJsonElementEquals CHARACTER '.nodes["seed.teradata.test_table"].columns.animal.type'
+assertJsonElementEquals CHARACTER '.nodes["seed.teradata.test_table"].columns.superpower.type'
+assertJsonElementEquals INTEGER '.nodes["seed.teradata.test_table"].columns.magic_index.type'
+
+assertJsonElementEquals CHARACTER '.nodes["model.teradata.table_from_source"].columns.animal.type'
+assertJsonElementEquals CHARACTER '.nodes["model.teradata.table_from_source"].columns.superpower.type'
+assertJsonElementEquals INTEGER '.nodes["model.teradata.table_from_source"].columns.magic_index.type'
+
+assertJsonElementEquals CHARACTER '.nodes["model.teradata.view_from_source"].columns.animal.type'
+assertJsonElementEquals CHARACTER '.nodes["model.teradata.view_from_source"].columns.superpower.type'
+assertJsonElementEquals INTEGER '.nodes["model.teradata.view_from_source"].columns.magic_index.type'
+

--- a/test/catalog/without_qvci/.gitignore
+++ b/test/catalog/without_qvci/.gitignore
@@ -1,4 +1,3 @@
 logs/
 target/
 dbt_modules/
-sampledata.csv

--- a/test/catalog/without_qvci/data/test_table.csv
+++ b/test/catalog/without_qvci/data/test_table.csv
@@ -1,0 +1,3 @@
+animal, superpower, magic_index
+unicorn, magic, 100
+pegasus, flying, 500

--- a/test/catalog/without_qvci/dbt_project.yml
+++ b/test/catalog/without_qvci/dbt_project.yml
@@ -1,0 +1,42 @@
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'teradata'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'teradata'
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_modules"
+
+#on-run-start:
+#  - "{{ install_dbt_drop_relation_if_exists() }}"
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  teradata:
+    +materialized: view
+
+seeds:
+  teradata:
+    +use_fastload: true

--- a/test/catalog/without_qvci/models/sources.yml
+++ b/test/catalog/without_qvci/models/sources.yml
@@ -1,0 +1,7 @@
+version: 2
+sources:
+  - name: alias_source_schema
+    schema: dbt_catalog_test
+    tables:
+      - name: alias_source_table
+        identifier: test_table

--- a/test/catalog/without_qvci/models/table_from_source.sql
+++ b/test/catalog/without_qvci/models/table_from_source.sql
@@ -1,0 +1,6 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}

--- a/test/catalog/without_qvci/models/view_from_source.sql
+++ b/test/catalog/without_qvci/models/view_from_source.sql
@@ -1,0 +1,6 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}

--- a/test/catalog/without_qvci/run.sh
+++ b/test/catalog/without_qvci/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+dbt -d seed --target dbt_catalog_test
+dbt -d run --target dbt_catalog_test
+dbt -d docs generate --target dbt_catalog_test
+
+
+assertJsonElementEquals() {
+  VALUE_IN_JSON=`cat target/catalog.json| jq -r $2`
+  if [ "$1" == "$VALUE_IN_JSON" ]; then
+    echo "Assert successful for '$1' and '$2'"
+    return
+  else
+    echo "Assert failed for $2. Was $VALUE_IN_JSON but expected $1"
+    exit 1
+  fi
+}
+
+# assert on target/catalog.json
+assertJsonElementEquals CHARACTER '.nodes["seed.teradata.test_table"].columns.animal.type'
+assertJsonElementEquals CHARACTER '.nodes["seed.teradata.test_table"].columns.superpower.type'
+assertJsonElementEquals INTEGER '.nodes["seed.teradata.test_table"].columns.magic_index.type'
+
+assertJsonElementEquals CHARACTER '.nodes["model.teradata.table_from_source"].columns.animal.type'
+assertJsonElementEquals CHARACTER '.nodes["model.teradata.table_from_source"].columns.superpower.type'
+assertJsonElementEquals INTEGER '.nodes["model.teradata.table_from_source"].columns.magic_index.type'
+
+assertJsonElementEquals 'N/A' '.nodes["model.teradata.view_from_source"].columns.animal.type'
+assertJsonElementEquals 'N/A' '.nodes["model.teradata.view_from_source"].columns.superpower.type'
+assertJsonElementEquals 'N/A' '.nodes["model.teradata.view_from_source"].columns.magic_index.type'
+

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -230,6 +230,57 @@ projects:
         rowcount: 4
       table_from_source:
         rowcount: 4
+  - name: validate_teradata_catalog
+    paths:
+      data/test_table.csv: |
+        id,attrA,attrB
+        1,val1A,val1B
+        2,val2A,val2B
+        3,val3A,val3B
+        4,val4A,val4B
+
+      models/table_from_source.sql: |
+        {{
+            config(
+                materialized='table'
+            )
+        }}
+        SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}
+
+      models/view_from_source.sql: |
+        {{
+            config(
+                materialized='view'
+            )
+        }}
+        SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}
+
+      models/sources.yml: |
+        version: 2
+        sources:
+          - name: alias_source_schema
+            schema: "{{ target.schema }}"
+            tables:
+              - name: alias_source_table
+                identifier: test_table
+    facts:
+      run:
+        length: 1
+      test_table:
+        rowcount: 4
+      table_from_source:
+        rowcount: 4
+      catalog:
+        nodes:
+          length: 3
+          names:
+            - test_table
+            - table_from_source
+            - view_from_source
+        sources:
+          length: 1
+          names:
+            - test_table
 
 sequences:
 
@@ -318,6 +369,29 @@ sequences:
         cmd: docs generate
       - type: run_results
         exists: True
+  test_dbt_teradata_catalog:
+    project: validate_teradata_catalog
+    sequence:
+      - type: dbt
+        cmd: seed
+      - type: run_results
+        exists: True
+      - type: dbt
+        cmd: run
+      - type: run_results
+        exists: True
+      - type: dbt
+        cmd: docs generate
+      - type: run_results
+        exists: True
+      - type: catalog
+        exists: True
+        nodes:
+          length: fact.catalog.nodes.length
+          names: fact.catalog.nodes.names
+        sources:
+          length: fact.catalog.sources.length
+          names: fact.catalog.sources.names
   test_dbt_teradata_seed_twice:
     project: validate_teradata_sources
     sequence:

--- a/test/performance/run.sh
+++ b/test/performance/run.sh
@@ -13,5 +13,5 @@ done
 
 mv /tmp/sampledata.csv data/
 
-# run dbt seed with 2m budget
-timeout 2m dbt -d seed --target dbt_perf_test
+# run dbt seed with 3m budget
+timeout 3m dbt -d seed --target dbt_perf_test


### PR DESCRIPTION
resolves #4 

### Description

* When the adapter is not able to detect a column type, it will return `N/A` instead of defaulting to `CHARACTER`.
* Resolved [Populate column types in dbt docs](https://github.com/Teradata/dbt-teradata/issues/4)
* Added automated tests for catalog generation.


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
