### PR TITLE
teradata__current_timestamp now returns a timestamp rather than a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix timestamp format in teradata__curent_timestamp macro
 * Use macro "information_schema_name(database)" instead of word "DBC" (https://github.com/Teradata/dbt-teradata/issues/19)
 * Remove unnecessary word "distinct" in macro "teradata__list_schemas(database)" https://github.com/Teradata/dbt-teradata/issues/18
+* `teradata__current_timestamp` now returns a timestamp rather than a string to address https://github.com/Teradata/dbt-teradata/issues/22
 
 ### Fixes
 

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -63,7 +63,7 @@
 {% endmacro %}
 
 {% macro teradata__current_timestamp() -%}
-CAST ( CAST (CURRENT_TIMESTAMP AS FORMAT 'YYYY-MM-DDBHH:MI:SS.S(F)Z') AS VARCHAR(32))
+CURRENT_TIMESTAMP(6)
 {%- endmacro %}
 
 {% macro teradata__rename_relation(from_relation, to_relation) -%}

--- a/dbt/include/teradata/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/teradata/macros/materializations/snapshot/snapshot.sql
@@ -1,6 +1,7 @@
 
 {% macro teradata__snapshot_string_as_time(timestamp) -%}
-    {%- set result = "TO_TIMESTAMP_TZ('" ~ timestamp ~ "')" -%}
+    {%- set timestamp_string = timestamp.strftime('%Y-%m-%d %H:%M:%S.%f%z') -%}
+    {%- set result = "TO_TIMESTAMP_TZ('" ~ "{0}:{1}".format(timestamp_string[:-2], timestamp_string[-2:]) ~ "')" -%}
     {{ return(result) }}
 {%- endmacro %}
 

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -617,8 +617,55 @@ projects:
 
   - name: validate_teradata_timestamp_macro
     paths:
-      models/dbcinfo.sql: |
-        select TO_TIMESTAMP({{ current_timestamp() }}) as timestamp_column
+      seeds/test_table_in_timestamp_macro_test.csv: |
+        id,attrA,attrB,create_date
+        1,val1A,val1B,2020-03-05
+        2,val2A,val2B,2020-04-05
+        3,val3A,val3B,2020-05-05
+        4,val4A,val4B,2020-10-05
+
+      snapshots/test_table_snapshot.sql: |
+        {% snapshot orders_snapshot %}
+
+        {{ config(
+          check_cols=['create_date'],
+          unique_key='id',
+          strategy='check',
+          target_schema='dbt_test_table_snapshot_schema'
+        ) }}
+        select * from {{ ref('test_table_in_timestamp_macro_test') }}
+
+        {% endsnapshot %}
+
+      macros/macros.sql: |
+        -- override this macro to simulate specific time with full seconds
+        {% macro teradata__current_timestamp() -%}
+          TO_TIMESTAMP_TZ('2022-01-27 15:15:21.000000-05:00')
+        {%- endmacro %}
+
+  - name: validate_teradata_freshness_test
+    paths:
+      models/data_with_timestamp.sql: |
+        {{
+          config(
+            materialized="table"
+          )
+        }}
+        select '100' as important_data, CURRENT_TIMESTAMP - INTERVAL '1' DAY   as timestamp_column
+
+      models/sources.yml: |
+        version: 2
+
+        sources:
+          - name: validate_teradata_freshness_test
+            schema: "{{ target.schema }}"
+            database: "{{ target.schema }}"
+            freshness: # default freshness
+              warn_after: {count: 24, period: hour}
+            loaded_at_field: timestamp_column
+            tables:
+              - name: data_with_timestamp
+
 
 sequences:
 
@@ -789,7 +836,23 @@ sequences:
     project: validate_teradata_timestamp_macro
     sequence:
       - type: dbt
+        cmd: seed
+      - type: run_results
+        exists: True
+      - type: dbt
+        cmd: snapshot
+      - type: run_results
+        exists: True
+
+  test_dbt_teradata_freshness_test:
+    project: validate_teradata_freshness_test
+    sequence:
+      - type: dbt
         cmd: run
+      - type: run_results
+        exists: True
+      - type: dbt
+        cmd: source freshness
       - type: run_results
         exists: True
 


### PR DESCRIPTION
resolves #22 

### Description

`teradata__current_timestamp` now returns a timestamp rather than a string

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
