### PR TITLE
Applies LOWER() to schema metadata queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-teradata 1.0.0a
 
 ### Features
-
+Applies LOWER() to schemas in list_schemas and list_schemas_without_caching
 ### Fixes
 
 ### Docs

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -1,7 +1,7 @@
 
 {% macro teradata__list_schemas(database) %}
     {% call statement('list_schemas', fetch_result=True, auto_begin=False) -%}
-        SELECT DatabaseName AS schema_name
+        SELECT LOWER(DatabaseName) AS schema_name
         FROM {{ information_schema_name(database) }}.DatabasesV
     {%- endcall %}
 
@@ -176,8 +176,8 @@ CURRENT_TIMESTAMP(6)
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     SELECT
       NULL AS "database",
-      TableName AS name,
-      DatabaseName AS "schema",
+      LOWER(TableName) AS name,
+      LOWER(DatabaseName) AS "schema",
       CASE WHEN TableKind = 'T' THEN 'table'
          WHEN TableKind = 'V' THEN 'view'
          ELSE TableKind


### PR DESCRIPTION
resolves #32 

### Description

This change fixes the issue where the Teradata environment operates in a mode that is not case sensitive and it is causing compilation errors for ambiguous schema names.

Note: This is a very crude implementation and suggestions are very welcome.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change