### PR TITLE
Adjust the Vantage Express download process to the new VE location

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Install Vantage Express
         shell: bash
         run: |
-          export VM_IMAGE_DIR="/tmp/downloads/VantageExpress17.10_Sles12"
-          DEFAULT_VM_NAME="vantage-express-17.10"
+          export VM_IMAGE_DIR="/tmp/downloads/VantageExpress17.20_Sles12"
+          DEFAULT_VM_NAME="vantage-express"
           VM_NAME="${VM_NAME:-$DEFAULT_VM_NAME}"
           vboxmanage createvm --name "$VM_NAME" --register --ostype openSUSE_64
           vboxmanage modifyvm "$VM_NAME" --ioapic on --memory 6000 --vram 128 --nic1 nat --cpus 3

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -28,10 +28,10 @@ jobs:
           echo "my IP address is: " $(ipconfig getifaddr en0)
           mkdir /tmp/downloads
           cd /tmp/downloads
-          curl -L 'https://downloads.teradata.com/download/cdn/database/teradata-express/VantageExpress17.10_Sles12_202108300444.7z' \
-            -H 'Cookie: $TD_DOWNLOADS_MAGIC_COOKIE' --compressed -o ve.7z
+          curl -L "https://d289lrf5tw1zls.cloudfront.net/database/teradata-express/VantageExpress17.20_Sles12_20220819081111.7z?Expires=1704067200&Key-Pair-Id=APKAJ3SWQUPWKYVMO2WQ&Signature=$VE_URL_SIGNATURE" \
+            --compressed -o ve.7z
         env:
-          TD_DOWNLOADS_MAGIC_COOKIE: ${{ secrets.TD_DOWNLOADS_MAGIC_COOKIE }}
+          VE_URL_SIGNATURE: ${{ secrets.VE_URL_SIGNATURE }}
 
       - name: Unzip Vantage Express
         shell: bash
@@ -58,13 +58,13 @@ jobs:
       - name: Install TTU
         shell: bash
         run: |
-          curl -L 'https://downloads.teradata.com/download/cdn/tools/ttu/TeradataToolsAndUtilitiesBase__macosx_x86_64.17.10.11.00.tar.gz' \
-            -H 'Cookie: $TD_DOWNLOADS_MAGIC_COOKIE' --compressed -o ttu.tar.gz
+          curl -L "https://d289lrf5tw1zls.cloudfront.net/tools/ttu/TeradataToolsAndUtilitiesBase__macosx_x86_64.17.20.08.00.tar.gz?Expires=1704067200&Key-Pair-Id=APKAJ3SWQUPWKYVMO2WQ&Signature=$TTU_URL_SIGNATURE" \
+            --compressed -o ttu.tar.gz
           tar -xzf ttu.tar.gz
 
           installer -pkg ./TeradataToolsAndUtilitiesBase/*.pkg -target CurrentUserHomeDirectory
         env:
-          TD_DOWNLOADS_MAGIC_COOKIE: ${{ secrets.TD_DOWNLOADS_MAGIC_COOKIE }}
+          TTU_URL_SIGNATURE: ${{ secrets.TTU_URL_SIGNATURE }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Resolves the CI build issue.


### Description

The location of Vantage Express and TTU binaries has changed. The binaries are used in the CI loop. We need to adjust the CI loop to this new location.


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
