### PR TITLE
connection-retries-implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ my-teradata-db-profile:
       port: <port>
 ```
 
+### Retries
+
+Allows an adapter to automatically try again when the attempt to open a new connection on the database has a transient, infrequent error. This option can be set using the `retries` configuration.
+Default value is 0.
+
+```yaml
+my-teradata-db-profile:
+  target: dev
+  outputs:
+    dev:
+      type: teradata
+      host: <host>
+      user: <user>
+      password: <password>
+      schema: dbt_test
+      tmode: ANSI
+      retries: 3
+```
+
 ### Other Teradata connection parameters
 
 The plugin also supports the following Teradata connection parameters:

--- a/dbt/adapters/teradata/connections.py
+++ b/dbt/adapters/teradata/connections.py
@@ -38,6 +38,7 @@ class TeradataCredentials(Credentials):
     partition: Optional[str] = None
     sip_support: Optional[str] = None
     teradata_values: Optional[str] = None
+    retries: int = 0
 
     _ALIASES = {
         "UID": "username",
@@ -174,6 +175,25 @@ class TeradataConnectionManager(SQLConnectionManager):
 
         # Save the transaction mode
         cls.TMODE = credentials.tmode
+
+        logger.debug("host: {}",credentials.server);
+        logger.debug("retries: {}",credentials.retries);
+
+        if credentials.retries > 0:
+            def connect():
+                connection.handle = teradatasql.connect(**kwargs)
+                connection.state = 'open'
+                return connection.handle
+
+            retryable_exceptions = [teradatasql.OperationalError,]
+
+            return cls.retry_connection(
+                connection,
+                connect=connect,
+                logger=logger,
+                retry_limit=credentials.retries,
+                retryable_exceptions=retryable_exceptions,
+            )
 
         try:
             connection.handle = teradatasql.connect(**kwargs)


### PR DESCRIPTION
Allows an adapter to automatically try again when the attempt to open a new connection on the database has a transient, infrequent error. This option can be set using the `retries` configuration. Default value is 0.

resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->


### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
