### PR TITLE
Apply on_schema_change effect on columns when it is set in configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/integration/.user.yml
 .history/
 .editorconfig
 .python-version
+logs/*

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -230,3 +230,30 @@ CURRENT_TIMESTAMP(6)
 
     {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}
 {% endmacro %}
+
+{% macro teradata__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
+
+  {% if add_columns is none %}
+    {% set add_columns = [] %}
+  {% endif %}
+  {% if remove_columns is none %}
+    {% set remove_columns = [] %}
+  {% endif %}
+
+  {% set sql -%}
+
+     alter {{ relation.type }} {{ relation }}
+
+            {% for column in add_columns %}
+               add {{ column.name }} {{ column.data_type }}{{ ',' if not loop.last }}
+            {% endfor %}{{ ',' if add_columns and remove_columns }}
+
+            {% for column in remove_columns %}
+                drop {{ column.name }}{{ ',' if not loop.last }}
+            {% endfor %}
+
+  {%- endset -%}
+
+  {% do run_query(sql) %}
+
+{% endmacro %}

--- a/dbt/include/teradata/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/helpers.sql
@@ -1,5 +1,8 @@
-{% macro incremental_upsert(tmp_relation, target_relation, unique_key=none, statement_name="main") %}
-    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+{% macro incremental_upsert(on_schema_change, tmp_relation, target_relation, existing_relation, unique_key=none, statement_name="main") %}
+    {% set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
+    {% if not dest_columns %}
+        {%- set dest_columns = adapterd.get_columns_in_relation(target_relation) -%}
+    {% endif %}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
 
     {%- if unique_key is not none -%}

--- a/dbt/include/teradata/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/helpers.sql
@@ -1,7 +1,7 @@
 {% macro incremental_upsert(on_schema_change, tmp_relation, target_relation, existing_relation, unique_key=none, statement_name="main") %}
     {% set dest_columns = process_schema_changes(on_schema_change, tmp_relation, existing_relation) %}
     {% if not dest_columns %}
-        {%- set dest_columns = adapterd.get_columns_in_relation(target_relation) -%}
+        {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {% endif %}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
 

--- a/dbt/include/teradata/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/incremental.sql
@@ -8,6 +8,8 @@
 {% set existing_relation = load_relation(this) %}
 {% set tmp_relation = make_temp_relation(this) %}
 
+{% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
+
 {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
 -- `BEGIN` happens here:
@@ -31,7 +33,7 @@
    {% do adapter.expand_target_column_types(
           from_relation=tmp_relation,
           to_relation=target_relation) %}
-   {% set build_sql = incremental_upsert(tmp_relation, target_relation, unique_key=unique_key) %}
+   {% set build_sql = incremental_upsert(on_schema_change, tmp_relation, target_relation, existing_relation, unique_key=unique_key) %}
    {% do to_drop.append(tmp_relation) %}
 {% endif %}
 

--- a/tests/functional/adapter/teradata_dbt/teradata_fixtures.py
+++ b/tests/functional/adapter/teradata_dbt/teradata_fixtures.py
@@ -127,6 +127,19 @@ table_from_source_for_catalog_test_sql="""
     SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}
 """
 
+table_from_source_for_catalog_with_schema_change_sql="""
+        {{
+            config(
+                materialized="incremental", on_schema_change='append_new_columns'
+            )
+        }}
+    SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}
+"""
+
+alter_table_add_new_column = """
+    ALTER TABLE {schema}.test_table ADD testColumn INTEGER
+"""
+
 view_from_source_for_catalog_test_sql="""
         {{
             config(

--- a/tests/functional/adapter/teradata_dbt/test_validate_teradata_on_schema_change.py
+++ b/tests/functional/adapter/teradata_dbt/test_validate_teradata_on_schema_change.py
@@ -1,0 +1,60 @@
+import pytest
+from pathlib import Path
+from dbt.tests.util import run_dbt , check_relation_types,relation_from_name
+
+from tests.functional.adapter.teradata_dbt.teradata_fixtures import(
+    test_table_csv,
+    table_with_cte_sql,
+    table_from_source_for_catalog_with_schema_change_sql,
+    alter_table_add_new_column,
+    sources_yml
+)
+
+class Test_validate_teradata_on_schema_change:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "validate_teradata_on_schema_change",
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "test_table.csv": test_table_csv
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_from_source_for_catalog_test.sql": table_from_source_for_catalog_with_schema_change_sql,
+            "sources.yml": sources_yml
+        }
+
+    def test_validate_teradata_cases(self,project):
+        result1=run_dbt(["seed"])
+        assert len(result1) == 1
+
+        result_statuses = sorted(r.status for r in result1)
+        assert result_statuses == ["success"]
+
+        result2=run_dbt(["run"])
+        assert len(result2)==1
+
+        relation1=relation_from_name(project.adapter,"table_from_source_for_catalog_test")
+        with_cte_result=project.run_sql(f"select * from {relation1}",fetch="all")
+        
+        # Expecting 3 columns
+        assert len(with_cte_result[0])==3
+
+        # Add a new column to the seed table
+        project.run_sql(alter_table_add_new_column);
+
+        # Re-run model
+        result2=run_dbt(["run"])
+        assert len(result2)==1
+
+        relation1=relation_from_name(project.adapter,"table_from_source_for_catalog_test")
+        with_cte_result=project.run_sql(f"select * from {relation1}",fetch="all")
+        
+        # Expecting 4 columns
+        assert len(with_cte_result[0])==4


### PR DESCRIPTION
resolves #48 

### Description

Previously on_schema_change configuration was not used in the incremental materializations. As a result, new (or removed) columns were not reflected in the table after running the models. 

With this change, we first calculate the new set of destination columns taking the on_schema_change configuration, and then apply them to the existing table.


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
