### PR TITLE
added dependency dbt-core 1.3.3 to remove the pytz dependency issue which exists with 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-
+Added dbt-core 1.3.3 dependency to dbt-teradata 1.3.3 to remove the pytz dependency that was there in dbt-core 1.3.0
 ### Docs
 
 ### Under the hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-Added dbt-core 1.3.3 dependency to dbt-teradata 1.3.3 to remove the pytz dependency that was there in dbt-core 1.3.0
+Added dbt-core 1.3.3 dependency to dbt-teradata 1.3.3 to remove the pytz dependency that was there in dbt-core 1.3.0 (https://github.com/dbt-labs/dbt-core/issues/7075)
 ### Docs
 
 ### Under the hood

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 #### Bump version
 
 1. Open a branch for the release
-    - `git checkout -b releases/1.3.0rc1`
+    - `git checkout -b releases/1.3.3rc1`
 1. Update [`CHANGELOG.md`](CHANGELOG.md) with the most recent changes
 1. Bump the version using [`bump2version`](https://github.com/c4urself/bump2version/#bump2version):
     1. Dry run first by running:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,8 +6,7 @@ tox~=3.2
 dbt-tests-adapter~=1.1
 pylava~=0.3.0
 teradatasql>=16.20.0.0
-dbt-core==1.3.0
+dbt-core==1.3.3
 MarkupSafe==2.0.1
 pytest-dotenv
-pytz
 -e .

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 7) or sys.version_info >= (3, 11):
 
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(this_directory, 'README.md')) as f:
+with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
@@ -45,7 +45,7 @@ setup(
         ],
     },
     install_requires=[
-        "dbt-core==1.3.0",
+        "dbt-core==1.3.3",
         "teradatasql>=16.20.0.0",
     ],
     classifiers=[


### PR DESCRIPTION
### Description

This PR adds the dependency of dbt-core 1.3,3 for patch release of dbt-teradata 1.3.3, to remove the 
`ModuleNotFoundError: No module named 'pytz'`
which persists with v1.3.0

### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
