### PR TITLE
overriden alter column type macro

### DIFF
--- a/dbt/include/teradata/macros/columns.sql
+++ b/dbt/include/teradata/macros/columns.sql
@@ -1,7 +1,5 @@
-/* This macro is used when there is mismatch in column types from source while incremental modelling.
-For e.g We had a incremental run already for a project and later some user came and played with column type of 
-one of the column of the source and changed it e.g from varchar(20) changed it to varchar(25)
-So to sync up the data types this macro comes into play.
+/* The macro had to be overridden for Teradata because original macro uses `column` keyword that is not supported
+ nor needed in Teradata's `ALTER TABLE` syntax.
 */
 {% macro teradata__alter_column_type(relation, column_name, new_column_type) -%}
   {#

--- a/dbt/include/teradata/macros/columns.sql
+++ b/dbt/include/teradata/macros/columns.sql
@@ -1,3 +1,8 @@
+/* This macro is used when there is mismatch in column types from source while incremental modelling.
+For e.g We had a incremental run already for a project and later some user came and played with column type of 
+one of the column of the source and changed it e.g from varchar(20) changed it to varchar(25)
+So to sync up the data types this macro comes into play.
+*/
 {% macro teradata__alter_column_type(relation, column_name, new_column_type) -%}
   {#
     1. Create a new column (w/ temp name and correct type)

--- a/dbt/include/teradata/macros/columns.sql
+++ b/dbt/include/teradata/macros/columns.sql
@@ -1,0 +1,29 @@
+{% macro teradata__alter_column_type(relation, column_name, new_column_type) -%}
+  {#
+    1. Create a new column (w/ temp name and correct type)
+    2. Copy data over to it
+    3. Drop the existing column (cascade!)
+    4. Rename the new column to existing column
+  #}
+  {%- set tmp_column = column_name + "__dbt_alter" -%}
+
+  -- running statements one by one as teradata doesn't allow running multiple DDL commands collectively in ANSI mode
+  -- and dbt-teradata supports ANSI mode only
+  
+  {% call statement('alter_column_type') %}
+    alter table {{ relation }} add {{ adapter.quote(tmp_column) }} {{ new_column_type }};
+  {% endcall %}
+
+  {% call statement('alter_column_type') %}
+    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};
+  {% endcall %}
+
+  {% call statement('alter_column_type') %}
+    alter table {{ relation }} drop {{ adapter.quote(column_name) }};
+  {% endcall %}
+
+  {% call statement('alter_column_type') %}
+    alter table {{ relation }} rename {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }};
+  {% endcall %}
+
+{% endmacro %}

--- a/tests/functional/adapter/test_alter_column_type.py
+++ b/tests/functional/adapter/test_alter_column_type.py
@@ -1,0 +1,92 @@
+import pytest
+from dbt.tests.util import run_dbt, check_relations_equal, relation_from_name
+from dbt.contracts.results import RunStatus
+
+initial_source_csv = """
+id,name,number
+1,Michael,100
+2,Kobe,200
+3,Lebron,300
+4,Derrick,400 """.lstrip()
+
+added_source_csv=initial_source_csv+"""
+5,Steph,500
+6,Tracy,600
+""".lstrip()
+
+model_incremental_sql="""
+select * from {{ source('raw', 'initial_source') }}
+{% if is_incremental() %}
+where id > (select max(id) from {{ this }})
+{% endif %}
+""".strip()
+
+config_materialized_incremental = """
+  {{ config(materialized="incremental") }}
+"""
+
+incremental_sql= model_incremental_sql+config_materialized_incremental
+
+
+schema_base_yml = """
+version: 2
+sources:
+  - name: raw
+    schema: "{{ target.schema }}"
+    tables:
+      - name: initial_source
+"""
+
+
+class Base_change_column_type:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+          "name": "project_alter_column_type",
+          "seeds": {"+column_types": {"name":"varchar(17)"}}
+
+        }
+    
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "initial_source.csv": initial_source_csv
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental.sql": incremental_sql, "schema.yml": schema_base_yml
+        }
+    
+    def test_alter_column_type(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        relation = relation_from_name(project.adapter, "initial_source")
+        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+        assert result[0] == 4
+
+        # run command
+        # the "seed_name" var changes the seed identifier in the schema file
+        results = run_dbt(["run"])
+        assert len(results) == 1
+
+        project.run_sql(f"alter table {relation} add name varchar(21)")
+        project.run_sql(f"insert into {relation} values (5,'Steph',500)")
+
+        results=run_dbt(["run"])
+        assert len(results) == 1
+
+        relation=relation_from_name(project.adapter, "initial_source")
+        result=project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+        assert result[0] == 5 
+
+
+class TestAlterColumnTypeTeradata(Base_change_column_type):
+    pass
+
+
+
+
+


### PR DESCRIPTION
resolves #77 

### Description

Problem was with one of the macro which has slightly different syntax than Teradata syntax.
So overridden the macro with correct syntax.


### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
