### PR TITLE
added support for incremental predicates in delete+insert strategy

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9','3.10', '3.11']
+        python: ['3.7.16', '3.8', '3.9','3.10', '3.11']
     runs-on: macos-12
     name: Functional test
     steps:

--- a/dbt/include/teradata/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/helpers.sql
@@ -19,7 +19,7 @@
 
 {% macro teradata__get_incremental_sql(strategy, target_relation, tmp_relation, unique_key, dest_columns,incremental_predicates) %}
   {% if strategy == 'delete+insert' %}
-    {% do return(teradata__get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns)) %}
+    {% do return(teradata__get_delete_insert_merge_sql(target_relation, tmp_relation, unique_key, dest_columns, incremental_predicates)) %}
   {% elif strategy == 'append' %}
     {% do return(teradata__get_incremental_append_sql(target_relation, tmp_relation,  dest_columns)) %}
   {% elif strategy == 'merge' %}

--- a/dbt/include/teradata/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/incremental.sql
@@ -11,7 +11,7 @@
 -- {#-- Validate early so we don't run SQL if the strategy is invalid --#}
 {% set strategy = teradata__validate_get_incremental_strategy(config) %}
 
-{% set incremental_predicates = config.get('incremental_predicates', none) %}
+{% set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) %}
 
 {% set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') %}
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,4 +9,5 @@ teradatasql>=16.20.0.0
 dbt-core==1.4.6
 MarkupSafe==2.0.1
 pytest-dotenv
+bz2file
 -e .

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,4 @@ teradatasql>=16.20.0.0
 dbt-core==1.4.6
 MarkupSafe==2.0.1
 pytest-dotenv
-bz2file
 -e .

--- a/tests/functional/adapter/incremental/test_incremental_predicates.py
+++ b/tests/functional/adapter/incremental/test_incremental_predicates.py
@@ -60,7 +60,7 @@ class TestIncrementalPredicatesDeleteInsertTeradata(BaseIncrementalPredicates):
         }
     pass
 
-'''
+
 class TestPredicatesDeleteInsertTeradata(BaseIncrementalPredicates):
     @pytest.fixture(scope="class")
     def models(self):
@@ -84,4 +84,4 @@ class TestPredicatesDeleteInsertTeradata(BaseIncrementalPredicates):
                 "+incremental_strategy": "delete+insert"
             }
         }
-'''
+

--- a/tests/functional/adapter/incremental/test_incremental_predicates.py
+++ b/tests/functional/adapter/incremental/test_incremental_predicates.py
@@ -1,0 +1,87 @@
+import pytest
+
+from dbt.tests.adapter.incremental.test_incremental_predicates import BaseIncrementalPredicates
+
+models__delete_insert_incremental_predicates_sql = """
+{{ config(
+    materialized = 'incremental',
+    unique_key = 'id'
+) }}
+
+{% if not is_incremental() %}
+
+select * from (select 1 as id, 'goodbye' as msg, 'purple' as color) as "dual"
+union all
+select * from (select 2 as id, 'anyway' as msg, 'red' as color) as "dual"
+union all
+select * from (select 3 as id, 'hey' as msg, 'blue' as color) as "dual"
+
+{% else %}
+
+-- delete will not happen on the above record where id = 2, so new record will be inserted instead
+select * from (select 1 as id, 'goodbye' as msg, 'purple' as color) as "dual"
+union all
+select * from (select 2 as id, 'yo' as msg, 'green' as color) as "dual"
+union all
+select * from (select 3 as id, 'hi' as msg, 'blue' as color) as "dual"
+
+{% endif %}
+"""
+
+seeds__expected_delete_insert_incremental_predicates_csv = """id,msg,color
+1,goodbye,purple
+2,anyway,red
+2,yo,green
+3,hi,blue
+"""
+
+class TestIncrementalPredicatesDeleteInsertTeradata(BaseIncrementalPredicates):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "delete_insert_incremental_predicates.sql": models__delete_insert_incremental_predicates_sql
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "expected_delete_insert_incremental_predicates.csv": seeds__expected_delete_insert_incremental_predicates_csv
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_predicates": [
+                    "id <> 2"
+                ],
+                "+incremental_strategy": "delete+insert"
+            }
+        }
+    pass
+
+'''
+class TestPredicatesDeleteInsertTeradata(BaseIncrementalPredicates):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "delete_insert_incremental_predicates.sql": models__delete_insert_incremental_predicates_sql
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "expected_delete_insert_incremental_predicates.csv": seeds__expected_delete_insert_incremental_predicates_csv
+        }
+    
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+predicates": [
+                    "id <> 2"
+                ],
+                "+incremental_strategy": "delete+insert"
+            }
+        }
+'''


### PR DESCRIPTION
### Description

Added support for incremental_predicates in delete+insert strategy and added testcases for the same.

![image](https://github.com/Teradata/dbt-teradata/assets/51814705/381a3e03-9811-4fff-994b-b443b4e977d7)




### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
