### PR TITLE
stub contracts

### DIFF
--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -26,6 +26,10 @@
   {%- set table_option = config.get('table_option', default='') -%}
   {%- set with_statistics = config.get('with_statistics', default=False)| as_bool -%}
   {%- set index = config.get('index', default='') -%}
+  {% set contract_config = config.get('contract') %}
+  {% if contract_config and contract_config.enforced %}
+    {{ exceptions.warn('Model contracts are not currently supported.') }}
+  {% endif %}
 
   {{ sql_header if sql_header is not none }}
   CREATE {{ table_kind }} TABLE
@@ -55,6 +59,10 @@
 
 {% macro teradata__create_view_as(relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
+  {% set contract_config = config.get('contract') %}
+  {% if contract_config and contract_config.enforced %}
+    {{ exceptions.warn('Model contracts are not currently supported.') }}
+  {% endif %}
 
   {{ sql_header if sql_header is not none }}
   REPLACE VIEW {{ relation.include(database=False) }} AS

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -28,7 +28,7 @@
   {%- set index = config.get('index', default='') -%}
   {% set contract_config = config.get('contract') %}
   {% if contract_config and contract_config.enforced %}
-    {{ exceptions.warn('Model contracts are not currently supported.') }}
+    {{ exceptions.raise_compiler_error('Model contracts are not currently supported.') }}
   {% endif %}
 
   {{ sql_header if sql_header is not none }}
@@ -61,7 +61,7 @@
   {%- set sql_header = config.get('sql_header', none) -%}
   {% set contract_config = config.get('contract') %}
   {% if contract_config and contract_config.enforced %}
-    {{ exceptions.warn('Model contracts are not currently supported.') }}
+    {{ exceptions.raise_compiler_error('Model contracts are not currently supported.') }}
   {% endif %}
 
   {{ sql_header if sql_header is not none }}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,10 +3,10 @@ bump2version
 wheel
 pytest~=7.0
 tox~=3.2
-dbt-tests-adapter~=1.5.2
+dbt-tests-adapter~=1.5.4
 pylava~=0.3.0
 teradatasql>=16.20.0.0
-dbt-core==1.5.2
+dbt-core==1.5.4
 MarkupSafe==2.0.1
 pytest-dotenv
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ],
     },
     install_requires=[
-        "dbt-core==1.5.2",
+        "dbt-core==1.5.4",
         "teradatasql>=16.20.0.0",
     ],
     classifiers=[


### PR DESCRIPTION
### Description

This PR is to raise an exception when model contracts are used with v1.5 as contracts are not yet supported with dbt-teradata adapter.


### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
