### PR TITLE
moved support of date_spine,generate_series and related macro to dbt-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,8 @@ For using cross DB macros, teradata-utils as a macro namespace will not be used,
 | Cross-database macros | type_string                   | :white_check_mark:    | custom macro provided                                                  |
 | Cross-database macros | last_day                      | :white_check_mark:    | no customization needed, see [compatibility note](#last_day)           |
 | Cross-database macros | width_bucket                  | :white_check_mark:    | no customization
+| SQL generators        | generate_series               | :white_check_mark:    | custom macro provided
+| SQL generators        | date_spine                    | :white_check_mark:    | no customization
 
 
 #### examples for cross DB macros

--- a/dbt/include/teradata/macros/utils/generate_series.sql
+++ b/dbt/include/teradata/macros/utils/generate_series.sql
@@ -1,0 +1,30 @@
+{# Overriding because the original implementation used 'WITH'. Since this query is used in 'date_spine' macro #}
+{# which is also 'WITH'-based, it resulted in a nested 'WITH' query which is not supported in Teradata #}
+
+{# only when '*' is qualified with a table/view name #}
+{% macro teradata__generate_series(upper_bound) %}
+    {{ log("upper_bound : " ~ upper_bound) }}
+
+    {% set n = get_powers_of_two(upper_bound|trim|int) %}
+
+    SELECT cast(
+    {% for i in range(n) %}
+    p{{i}}.gen_number * power(2, {{i}})
+    {% if not loop.last %} + {% endif %}
+    {% endfor %}
+    + 1
+    AS integer) AS generated_number
+
+    from
+
+    {% for i in range(n) %}
+    (SELECT * FROM ( SELECT 0 AS gen_number ) t
+        UNION ALL
+        SELECT * FROM ( SELECT 1 AS gen_number ) t) AS p{{i}}
+    {% if not loop.last %} cross join {% endif %}
+    {% endfor %}
+
+
+    WHERE generated_number <= {{upper_bound}}
+
+{% endmacro %}

--- a/tests/functional/adapter/utils/fixtures_utils.py
+++ b/tests/functional/adapter/utils/fixtures_utils.py
@@ -318,3 +318,76 @@ models:
           actual: actual
           expected: expected
 """
+
+
+####################################################################### END ###################################################
+
+################################################################################################################################
+# fixtures for "test_generate_series"
+################################################################################################################################
+
+models__test_generate_series_sql = """
+with generated_numbers as (
+    {{ dbt.generate_series(10) }}
+), expected_numbers as (
+    select 1  as expected FROM (SELECT 1 AS "DUMMY") AS "DUAL"
+    union all
+    select 2 as expected FROM (SELECT 2 AS "DUMMY") AS "DUAL"
+    union all
+    select 3 as expected FROM (SELECT 3 AS "DUMMY") AS "DUAL"
+    union all
+    select 4 as expected FROM (SELECT 4 AS "DUMMY") AS "DUAL"
+    union all
+    select 5 as expected FROM (SELECT 5 AS "DUMMY") AS "DUAL"
+    union all
+    select 6 as expected FROM (SELECT 6 AS "DUMMY") AS "DUAL"
+    union all
+    select 7 as expected FROM (SELECT 7 AS "DUMMY") AS "DUAL"
+    union all
+    select 8 as expected FROM (SELECT 8 AS "DUMMY") AS "DUAL"
+    union all
+    select 9 as expected FROM (SELECT 9 AS "DUMMY") AS "DUAL"
+    union all
+    select 10 as expected FROM (SELECT 10 AS "DUMMY") AS "DUAL"
+), joined as (
+    select
+        generated_numbers.generated_number,
+        expected_numbers.expected
+    from generated_numbers
+    left join expected_numbers on generated_numbers.generated_number = expected_numbers.expected
+)
+
+SELECT * from joined
+"""
+
+models__test_generate_series_yml = """
+version: 2
+models:
+  - name: test_generate_series
+    tests:
+      - assert_equal:
+          actual: generated_number
+          expected: expected
+"""
+
+####################################################################### END ###################################################
+
+################################################################################################################################
+# fixtures for "get_intervals_between"
+################################################################################################################################
+
+models__test_get_intervals_between_sql = """
+SELECT
+  {{ get_intervals_between("'2023-01-09'", "'2023-12-09'", "month") }} as intervals,
+  11 as expected
+"""
+
+models__test_get_intervals_between_yml = """
+version: 2
+models:
+  - name: test_get_intervals_between
+    tests:
+      - assert_equal:
+          actual: intervals
+          expected: expected
+"""

--- a/tests/functional/adapter/utils/test_date_spine.py
+++ b/tests/functional/adapter/utils/test_date_spine.py
@@ -1,0 +1,47 @@
+import pytest
+from dbt.tests.util import run_dbt , check_relation_types,relation_from_name
+
+report_sql="""
+        {{
+          config(
+            materialized="table"
+          )
+        }}
+        {{ date_spine(
+            datepart="day",
+            start_date="cast('2019-01-01' as date)",
+            end_date="cast('2021-01-01' as date)"
+          )
+        }}
+"""
+
+class Test_date_spine:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "project_for_test",
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "report.sql": report_sql
+        }
+    
+    def test_validate_date_spine(self,project):
+        result=run_dbt(["run"])
+        assert len(result) == 1
+
+        result_statuses = sorted(r.status for r in result)
+        print(result_statuses)
+        assert result_statuses == ["success"]
+
+        relation=relation_from_name(project.adapter,"report")
+        no_of_rows=project.run_sql(f"select count(*) as num_rows from {relation}",fetch="one")
+        assert relation.identifier=="report"
+        assert no_of_rows[0]==731
+        
+
+        
+
+

--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -2,6 +2,7 @@ import pytest
 from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestamp
 from dbt.tests.adapter.utils.test_hash import BaseHash
 from tests.functional.adapter.utils.base_utils import BaseUtils
+from dbt.tests.adapter.utils.test_get_powers_of_two import BaseGetPowersOfTwo
 from tests.functional.adapter.utils.fixtures_utils import( 
     seeds__data_date_trunc_csv, 
     models__test_date_trunc_sql,
@@ -23,6 +24,10 @@ from tests.functional.adapter.utils.fixtures_utils import(
     seeds__data_hash_csv,
     models__test_hash_sql,
     models__test_hash_yml,
+    models__test_generate_series_sql,
+    models__test_generate_series_yml,
+    models__test_get_intervals_between_sql,
+    models__test_get_intervals_between_yml,
     )
 
 
@@ -144,3 +149,30 @@ class TestSplitPart(BaseUtils):
         }
     pass
 
+
+class TestGenerateSeries(BaseUtils):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_generate_series.yml": models__test_generate_series_yml,
+            "test_generate_series.sql": self.interpolate_macro_namespace(
+                models__test_generate_series_sql, "generate_series"
+            ),
+        }
+    
+    pass
+
+class TestGetIntervalsBetween(BaseUtils):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_get_intervals_between.yml": models__test_get_intervals_between_yml,
+            "test_get_intervals_between.sql": self.interpolate_macro_namespace(
+                models__test_get_intervals_between_sql, "get_intervals_between"
+            ),
+        }
+    
+    pass
+
+class TestGetPowersOfTwo(BaseGetPowersOfTwo):
+    pass


### PR DESCRIPTION
resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description

This PR moves the support of date_spine(), generate_series(), get_intervals_between(), get_powers_of_two() macros from dbt-teradata-utils to dbt-teradata.

![image](https://github.com/Teradata/dbt-teradata/assets/51814705/9517c43a-260b-4216-87e6-46847a24d127)



### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
