### PR TITLE
Missing raise for CompilationError in TeradataAdapter._get_one_catalog()

### DIFF
--- a/dbt/adapters/teradata/impl.py
+++ b/dbt/adapters/teradata/impl.py
@@ -169,7 +169,7 @@ class TeradataAdapter(SQLAdapter):
         manifest: Manifest,
     ) -> agate.Table:
         if len(schemas) != 1:
-            dbt.exceptions.CompilationError(
+            raise dbt.exceptions.CompilationError(
                 f'Expected only one schema in _get_one_catalog() for Teradata adapter, found '
                 f'{schemas}'
             )


### PR DESCRIPTION
resolves #

https://github.com/Teradata/dbt-teradata/issues/133

It seems that during the upgrade to dbt 1.4 the code was refactored to use the new dbt exceptions where in once instance the exception is being constructed but not being raised:

```
            dbt.exceptions.CompilationError(
                f'Expected only one schema in _get_one_catalog() for Teradata adapter, found '
                f'{schemas}'
            )
```