### PR TITLE
Added support for JSON column type and testcase

### DIFF
--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -167,6 +167,7 @@
         WHEN ColumnsV.ColumnType = 'SZ' THEN 'TIMESTAMP WITH TIME ZONE'
         WHEN ColumnsV.ColumnType = 'UT' THEN 'USER‑DEFINED TYPE'
         WHEN ColumnsV.ColumnType = 'XM' THEN 'XML'
+        WHEN ColumnsV.ColumnType = 'JN' THEN 'JSON'
         ELSE 'N/A'
       END AS dtype,
       CASE

--- a/tests/functional/adapter/test_get_columns_in_relation.py
+++ b/tests/functional/adapter/test_get_columns_in_relation.py
@@ -1,3 +1,14 @@
+"""
+We will be creating a seed table from 'sample_seed_csv'.
+If we look at the 'project_config_update': we can see se are setting the datatype of 'json_column' as JSON.
+In 'model_model_sql' model, we will fetch the columns,datatypes and few other fields of sample_seed table with help of
+macro 'get_columns_in_relation'.
+As we have now added support for JSON datatype, we will retrieve JSON datatype for 'json_column' and will build the
+'model_model_sql' model.
+Previously it would have returned N/A as datatype for 'json_column' and would have failed to build the
+'model_model_sql'
+"""
+
 import pytest
 from dbt.tests.util import run_dbt
 

--- a/tests/functional/adapter/test_get_columns_in_relation.py
+++ b/tests/functional/adapter/test_get_columns_in_relation.py
@@ -21,13 +21,6 @@ from {{ ref('sample_seed') }}
 sel * from source
 """
 
-# generate_column_names_sql="""
-# {% macro generate_column_names(model) -%}
-#     {% set columns = adapter.get_columns_in_relation(ref('model')) %}
-#     {{ return(columns) }}
-# {%- endmacro %}
-# """
-
 class Test_columns_in_relation:
 
     @pytest.fixture(scope="class")
@@ -53,12 +46,6 @@ class Test_columns_in_relation:
         return{
             "models__model.sql": models__model_sql,
         }
-
-    # @pytest.fixture(scope="class")
-    # def macros(self):
-    #     return {
-    #         "generate_column_names.sql": generate_column_names_sql
-    #     }
 
     def test_get_columns_in_relation(self, project):
         results=run_dbt(["seed"])

--- a/tests/functional/adapter/test_get_columns_in_relation.py
+++ b/tests/functional/adapter/test_get_columns_in_relation.py
@@ -1,0 +1,74 @@
+import pytest
+from dbt.tests.util import run_dbt, run_dbt_and_capture, relation_from_name
+
+sample_seed_csv = """
+id,json_column
+1,{"id": 1}
+2,{"id": 2}
+3,{"id": 3}
+4,{"id": 4} """.lstrip()
+
+models__model_sql = """
+with source as (
+select 
+{% set columns = adapter.get_columns_in_relation(ref('sample_seed')) %}
+{% for column in columns %}
+    cast({{ column.column }} as {{column.dtype}}) as {{ column.column }}
+    {%- if not loop.last %}, {% endif %}
+{% endfor %}
+from {{ ref('sample_seed') }}
+)
+sel * from source
+"""
+
+# generate_column_names_sql="""
+# {% macro generate_column_names(model) -%}
+#     {% set columns = adapter.get_columns_in_relation(ref('model')) %}
+#     {{ return(columns) }}
+# {%- endmacro %}
+# """
+
+class Test_columns_in_relation:
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "get_columns_in_relation",
+            "seeds": {"get_columns_in_relation":
+                          {"sample_seed":
+                               {"+column_types":
+                                    {"json_column": "JSON"}
+                                }
+                           }
+                      }
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "sample_seed.csv": sample_seed_csv
+        }
+    @pytest.fixture(scope="class")
+    def models(self):
+        return{
+            "models__model.sql": models__model_sql,
+        }
+
+    # @pytest.fixture(scope="class")
+    # def macros(self):
+    #     return {
+    #         "generate_column_names.sql": generate_column_names_sql
+    #     }
+
+    def test_get_columns_in_relation(self, project):
+        results=run_dbt(["seed"])
+        assert len(results) == 1
+
+        result_statuses = sorted(r.status for r in results)
+        assert result_statuses == ['success']
+
+        result2 = run_dbt(["run"])
+        assert len(result2) == 1
+
+        result_statuses = sorted(r.status for r in result2)
+        assert result_statuses == ['success']

--- a/tests/functional/adapter/test_get_columns_in_relation.py
+++ b/tests/functional/adapter/test_get_columns_in_relation.py
@@ -1,5 +1,5 @@
 import pytest
-from dbt.tests.util import run_dbt, run_dbt_and_capture, relation_from_name
+from dbt.tests.util import run_dbt
 
 sample_seed_csv = """
 id,json_column


### PR DESCRIPTION
resolves #142 


### Description

PR adds support fr JSON type column 
Testcase has been added for the same

**Log output of the testcase before Changes**
```
Invoking dbt with ['run']
11:20:48  Running with dbt=1.7.4
11:20:48  Registered adapter: teradata=1.0.0
11:20:49  Found 1 model, 1 seed, 0 sources, 0 exposures, 0 metrics, 413 macros, 0 groups, 0 semantic models
11:20:49
11:20:59  Concurrency: 1 threads (target='default')
11:20:59
11:20:59  1 of 1 START sql view model dbt_test_17085144123235305627.models__model ........ [RUN]
11:21:05  1 of 1 ERROR creating sql view model dbt_test_17085144123235305627.models__model  [ERROR in 6.00s]
11:21:05
11:21:05  Finished running 1 view model in 0 hours 0 minutes and 16.34 seconds (16.34s).
11:21:05
11:21:05  Completed with 1 error and 0 warnings:
11:21:05
11:21:05    Database Error in model models__model (models\models__model.sql)
  [Version 20.0.0.1] [Session 9359] [Teradata Database] [Error 3706] Syntax error: Data Type "N" does not match a Defined Type name.
   at gosqldriver/teradatasql.formatError ErrorUtil.go:85
```


**Log output of the testcase after Changes**
```
(venv) PS C:\Users\vs255034\OneDrive - Teradata\Desktop\dbt-teradata> pytest -v .\tests\functional\adapter\test_get_columns_in_relation.py
=============================================================================== test session starts =============================================================================== 
platform win32 -- Python 3.11.7, pytest-7.4.3, pluggy-1.3.0 -- C:\Users\vs255034\OneDrive - Teradata\Desktop\dbt-teradata\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\vs255034\OneDrive - Teradata\Desktop\dbt-teradata
configfile: pytest.ini
plugins: pylava-0.3.0, cov-4.1.0, dotenv-0.5.2
collected 1 item

tests/functional/adapter/test_get_columns_in_relation.py::Test_columns_in_relation::test_get_columns_in_relation PASSED                                                      [100%]

========================================================================== 1 passed in 66.10s (0:01:06) ===========================================================================

```
