### PR TITLE
Fix contract enforcement logic

### DIFF
--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -41,7 +41,7 @@
       {{ get_assert_columns_equivalent(sql) }}
 
       {# below macro loop through user_provided_columns to create DDL with data types and constraints #}
-      {{ get_table_columns_and_constraints() }} ;
+      {{ get_table_columns_and_constraints() }}
 
       {%- if with_statistics -%}
       AND STATISTICS


### PR DESCRIPTION
resolves #144 


### Description

Remove extra semicolon in adapters.sql in the enforced contract logic that was causing the issue


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
