### PR TITLE
Overridden method for --empty flag support in dbt-teradata

### DIFF
--- a/dbt/adapters/teradata/relation.py
+++ b/dbt/adapters/teradata/relation.py
@@ -30,3 +30,14 @@ class TeradataRelation(BaseRelation):
                 "include, but only one can be set"
             )
         return super().render()
+
+    ''' overriding render_limited() method because super method uses LIMIT clause which is not supported in Teradata
+        This method is used when --empty flag in dbt run command is used for dry run of models '''
+    def render_limited(self) -> str:
+        rendered = self.render()
+        if self.limit is None:
+            return rendered
+        elif self.limit == 0:
+            return f"(select * from {rendered} sample 0) _dbt_limit_subq"
+        else:
+            return f"(select * from {rendered} sample {self.limit}) _dbt_limit_subq"

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,0 +1,5 @@
+from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+
+
+class TestEmptyTeradata(BaseTestEmpty):
+    pass


### PR DESCRIPTION
### Description

This PR adds support for --empty flag in dbt-teradata
Overriding render_limited() method because super method uses LIMIT clause which is not supported in Teradata

Test Result:
![image](https://github.com/Teradata/dbt-teradata/assets/51814705/e07f2158-53f1-41d0-a2f6-38da310c677c)



### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
