### PR TITLE
Fix create table as with

### DIFF
--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -65,19 +65,11 @@
       {{ relation.include(database=False) }}
       {% if table_option |length -%}
       , {{ table_option }}
-      {%- endif -%}
-      {% if sql.strip().upper().startswith('WITH') %}
-        AS (
-          SELECT * FROM (
-            {{ sql }}
-          ) D
-        ) with no data
-      {% else %}
+      {% endif -%}
         AS (
             {{ sql }}
-          )with no data
-      {% endif %}
-      {%- if with_statistics -%}
+        ) WITH NO DATA
+      {% if with_statistics -%}
         AND STATISTICS
       {%- endif %}
       {% if index |length -%}
@@ -85,15 +77,8 @@
       {%- endif -%};
     {% endcall %}
 
-    insert into {{ relation }}
-      {% if sql.strip().upper().startswith('WITH') %}
-
-        SELECT * FROM (
+    INSERT INTO {{ relation }}
           {{ sql }}
-      ) D
-    {% else %}
-          {{ sql }}
-    {% endif %}
     ;
   {% endif %}
 {% endmacro %}

--- a/dbt/include/teradata/macros/materializations/incremental/helpers.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/helpers.sql
@@ -10,7 +10,7 @@
     Expected one of:  'append','delete+insert','merge'
   {%- endset %}
   {%- if strategy not in ['append','delete+insert','merge'] %}
-    {% do exceptions.CompilationError(invalid_strategy_msg) %}
+    {% do exceptions.raise_compiler_error(invalid_strategy_msg) %}
   {%- endif %}
 
   {% do return(strategy) %}
@@ -25,6 +25,6 @@
   {% elif strategy == 'merge' %}
     {% do return(teradata__get_merge_sql(target_relation, tmp_relation, unique_key, dest_columns,incremental_predicates)) %}
   {% else %}
-    {% do exceptions.CompilationError("Invalid Strategy") %}
+    {% do exceptions.raise_compiler_error("Invalid Strategy") %}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/teradata/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/teradata/macros/materializations/incremental/strategies.sql
@@ -90,7 +90,7 @@
     {% else %}
         {% set error_msg= "Unique key is required for merge incremental strategy, please provide unique key in configuration and try again
         or consider using Append strategy" %}
-        {% do exceptions.CompilationError(error_msg) %}
+        {% do exceptions.raise_compiler_error(error_msg) %}
     {% endif %}
 
     {{ sql_header if sql_header is not none }}

--- a/dbt/include/teradata/macros/materializations/seed/seed.sql
+++ b/dbt/include/teradata/macros/materializations/seed/seed.sql
@@ -75,7 +75,7 @@
   -- build model
   {% set create_table_sql = "" %}
   {% if exists_as_view %}
-    {{ exceptions.CompilationError("Cannot seed to '{}', it is a view".format(old_relation)) }}
+    {{ exceptions.raise_compiler_error("Cannot seed to '{}', it is a view".format(old_relation)) }}
   {% elif exists_as_table %}
     {% set create_table_sql = reset_csv_table(model, full_refresh_mode, old_relation, agate_table) %}
   {% else %}

--- a/test/integration/seed_modifiers.dbtspec
+++ b/test/integration/seed_modifiers.dbtspec
@@ -24,6 +24,7 @@ projects:
         seeds:
           project_table_modifiers_with_seed_table_kind:
             table_kind: "SET"
+            index: "UNIQUE PRIMARY INDEX (id)"
 
   - name: project_table_modifiers_with_seed_table_option
     paths:

--- a/tests/functional/adapter/test_run_results_json.py
+++ b/tests/functional/adapter/test_run_results_json.py
@@ -15,7 +15,8 @@ model_sql = """
 config( 
     materialized = 'incremental', 
     incremental_strategy = 'merge',
-    unique_key = 'id' 
+    unique_key = 'id',
+    index = 'UNIQUE PRIMARY INDEX (id)'
 )
 }}
 sel * from {{ ref('seed') }}


### PR DESCRIPTION
resolves #161 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description
This PR addresses the following:
1. Fix integration test test/integration/seed_modifiers.dbtspec::table_modifiers_with_seed_table_kind
2. Correct the compilation error exception throwing by converting exceptions.CompilationError to exceptions.raise_compiler_error in dbt/include/teradata/macros/materialzations
3. Fix tests in tests/functional/adapter/test_run_results_json.py
4. Remove unnecessary WITH handling logic in  macro teradata__create_table_as

<!--- Describe the Pull Request here -->


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
