### PR TITLE
IDE-24432: Upgraded teradatasql driver to 20.00.00.10

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ pytest~=7.0
 tox~=3.2
 dbt-tests-adapter~=1.7.11
 pylava~=0.3.0
-teradatasql>=16.20.0.0
+teradatasql>=20.00.00.10
 dbt-core==1.7.11
 MarkupSafe==2.0.1
 pytest-dotenv

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     },
     install_requires=[
         "dbt-core==1.7.11",
-        "teradatasql>=16.20.0.0",
+        "teradatasql>=20.00.00.10",
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
“activityname” attribute was added in the teradatasql driver 20.00.00.08 version

resolves https://github.com/Teradata/dbt-teradata/issues/155