### PR TITLE
Add package installation backwards compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,10 @@ setup(
         ],
     },
     install_requires=[
-        "dbt-adapters>=1.2.1",
-        "dbt-common>=1.3.0",
+        "dbt-adapters>=1.2.1,<2.0",
+        "dbt-common>=1.3.0,<2.0",
+        # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
+        "dbt-core>=1.8.0",
         "teradatasql>=20.00.00.10",
     ],
     classifiers=[


### PR DESCRIPTION

### Description
Preserve the experience of the package installation prior to the release of dbt-core 1.8.0.
This is similar to the other adapters' approach:
https://github.com/dbt-labs/dbt-redshift/blob/main/setup.py
https://github.com/dbt-labs/dbt-bigquery/blob/main/setup.py
https://github.com/dbt-labs/dbt-redshift/blob/main/setup.py

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
