### PR TITLE
enabling browser option for logmech

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ At a minimum, you need to specify `host`, `user`, `password`, `schema` (database
 
 The logon mechanism for Teradata jobs that dbt executes can be configured with the `logmech` configuration in your Teradata profile. The `logmech` field can be set to: `TD2`, `LDAP`, `BROWSER`, `KRB5`, `TDNEGO`. For more information on authentication options, go to [Teradata Vantage authentication documentation](https://docs.teradata.com/r/8Mw0Cvnkhv1mk1LEFcFLpw/0Ev5SyB6_7ZVHywTP7rHkQ).
 
+> For the initial BROWSER authentication, the browser opens as expected, asking for the credentials. However, for every subsequent connection, a new browser tab opens, displaying the message 'TERADATA BROWSER AUTHENTICATION COMPLETED,' despite using an existing BROWSER session silently. This is the default behavior of the teradatasql driver, and there is no way to avoid this at the present time.
+
+
 ```yaml
 my-teradata-db-profile:
   target: dev
@@ -708,9 +711,6 @@ To find more on model contracts please follow dbt documentations https://docs.ge
 ### Transaction mode
 Both ANSI and TERA modes are now supported in dbt-teradata. TERA mode's support is introduced with dbt-teradata 1.7.1, it is an initial implementation.
 ###### IMPORTANT NOTE: This is an initial implementation of the TERA transaction mode and may not support some use cases. We strongly advise validating all records or transformations utilizing this mode to preempt any potential anomalies or errors
-
-### BROWSER based authentication
-For the initial BROWSER authentication, the browser opens as expected, asking for the credentials. However, for every subsequent connection, a new browser tab opens, displaying the message 'TERADATA BROWSER AUTHENTICATION COMPLETED,' despite using an existing BROWSER session silently. This is the default behavior of the teradatasql driver, and there is no way to avoid this at the present time.
 
 ## Query Band
 Query Band in dbt-teradata can be set on three levels:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ At a minimum, you need to specify `host`, `user`, `password`, `schema` (database
 
 ### Logmech
 
-The logon mechanism for Teradata jobs that dbt executes can be configured with the `logmech` configuration in your Teradata profile. The `logmech` field can be set to: `TD2`, `LDAP`, `KRB5`, `TDNEGO`. For more information on authentication options, go to [Teradata Vantage authentication documentation](https://docs.teradata.com/r/8Mw0Cvnkhv1mk1LEFcFLpw/0Ev5SyB6_7ZVHywTP7rHkQ).
+The logon mechanism for Teradata jobs that dbt executes can be configured with the `logmech` configuration in your Teradata profile. The `logmech` field can be set to: `TD2`, `LDAP`, `BROWSER`, `KRB5`, `TDNEGO`. For more information on authentication options, go to [Teradata Vantage authentication documentation](https://docs.teradata.com/r/8Mw0Cvnkhv1mk1LEFcFLpw/0Ev5SyB6_7ZVHywTP7rHkQ).
 
 ```yaml
 my-teradata-db-profile:
@@ -708,6 +708,9 @@ To find more on model contracts please follow dbt documentations https://docs.ge
 ### Transaction mode
 Both ANSI and TERA modes are now supported in dbt-teradata. TERA mode's support is introduced with dbt-teradata 1.7.1, it is an initial implementation.
 ###### IMPORTANT NOTE: This is an initial implementation of the TERA transaction mode and may not support some use cases. We strongly advise validating all records or transformations utilizing this mode to preempt any potential anomalies or errors
+
+### BROWSER based authentication
+For the initial BROWSER authentication, the browser opens as expected, asking for the credentials. However, for every subsequent connection, a new browser tab opens, displaying the message 'TERADATA BROWSER AUTHENTICATION COMPLETED,' despite using an existing BROWSER session silently. This is the default behavior of the teradatasql driver, and there is no way to avoid this at the present time.
 
 ## Query Band
 Query Band in dbt-teradata can be set on three levels:

--- a/dbt/adapters/teradata/connections.py
+++ b/dbt/adapters/teradata/connections.py
@@ -70,11 +70,17 @@ class TeradataCredentials(Credentials):
     }
 
     def __post_init__(self):
-        if self.username is None:
-            raise dbt_common.exceptions.DbtRuntimeError("Must specify `user` in profile")
-        elif self.password is None:
-            raise dbt_common.exceptions.DbtRuntimeError("Must specify `password` in profile")
-        elif self.schema is None:
+        if self.logmech is not None and self.logmech.lower() == "browser":
+            # When logmech is "browser", username and password should not be provided.
+            if self.username is not None or self.password is not None:
+                raise dbt_common.exceptions.DbtRuntimeError(
+                    "Username and password should not be specified when logmech is 'browser'")
+        else:
+            if self.username is None:
+                raise dbt_common.exceptions.DbtRuntimeError("Must specify `user` in profile")
+            elif self.password is None:
+                raise dbt_common.exceptions.DbtRuntimeError("Must specify `password` in profile")
+        if self.schema is None:
             raise dbt_common.exceptions.DbtRuntimeError("Must specify `schema` in profile")
         # teradata classifies database and schema as the same thing
         if (


### PR DESCRIPTION
IDE-24569 - dbt: Validate and implement SSO support with dbt-teradata adapter

```
jaffle_shop:
  outputs:
    dev:
      type: teradata
      host: tdttu-tdvm-smp-1157.labs.teradata.com
      logmech: browser
      schema: jaffle_shop
      tmode: ANSI
      threads: 1
      timeout_seconds: 300
      priority: interactive
      retries: 1
  target: dev
```

![image](https://github.com/user-attachments/assets/3d4a606b-cb2f-4128-93be-5d35072ec095)

![image](https://github.com/user-attachments/assets/0c574f45-4f78-419b-9544-e397c49e57b3)

![image](https://github.com/user-attachments/assets/b22ad57a-8949-4b00-9d03-e034a2df55a6)

![image](https://github.com/user-attachments/assets/72f88702-7fb2-4241-b82e-ad45a7a1efd4)

```
(venv) PS C:\GitHub\dbt-teradata\jaffle_shop-dev> dbt build              
01:29:46  Running with dbt=1.8.4
01:29:46  Registered adapter: teradata=1.0.0
01:29:46  Unable to do partial parsing because saved manifest not found. Starting full parse.
01:29:48  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
01:29:48  Found 8 models, 3 seeds, 20 data tests, 442 macros
01:29:48  
01:30:09  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:30:22  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:30:35  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:30:36  Concurrency: 1 threads (target='dev')
01:30:36  
01:30:36  1 of 31 START seed file jaffle_shop.raw_customers .............................. [RUN]
01:30:47  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:30:49  1 of 31 OK loaded seed file jaffle_shop.raw_customers .......................... [INSERT 100 in 13.00s]
01:30:49  2 of 31 START seed file jaffle_shop.raw_orders ................................. [RUN]
01:30:59  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:31:01  2 of 31 OK loaded seed file jaffle_shop.raw_orders ............................. [INSERT 99 in 11.86s]
01:31:01  3 of 31 START seed file jaffle_shop.raw_payments ............................... [RUN]
01:31:12  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:31:14  3 of 31 OK loaded seed file jaffle_shop.raw_payments ........................... [INSERT 113 in 13.02s]
01:31:14  4 of 31 START sql view model jaffle_shop.stg_customers ......................... [RUN]
01:31:24  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:31:27  4 of 31 OK created sql view model jaffle_shop.stg_customers .................... [activity: Create View, rows_affected: 0 in 13.07s]
01:31:27  5 of 31 START sql view model jaffle_shop.stg_orders ............................ [RUN]
01:31:38  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:31:41  5 of 31 OK created sql view model jaffle_shop.stg_orders ....................... [activity: Create View, rows_affected: 0 in 14.10s]
01:31:41  6 of 31 START sql view model jaffle_shop.stg_payments .......................... [RUN]
01:31:51  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:31:54  6 of 31 OK created sql view model jaffle_shop.stg_payments ..................... [activity: Create View, rows_affected: 0 in 12.89s]
01:31:54  7 of 31 START test not_null_stg_customers_customer_id .......................... [RUN]
01:32:05  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:32:06  7 of 31 PASS not_null_stg_customers_customer_id ................................ [PASS in 12.05s]
01:32:06  8 of 31 START test unique_stg_customers_customer_id ............................ [RUN]
01:32:17  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:32:18  8 of 31 PASS unique_stg_customers_customer_id .................................. [PASS in 12.02s]
01:32:18  9 of 31 START test accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned  [RUN]
01:32:29  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:32:30  9 of 31 PASS accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned  [PASS in 11.55s]
01:32:30  10 of 31 START test not_null_stg_orders_order_id ............................... [RUN]
01:32:40  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:32:41  10 of 31 PASS not_null_stg_orders_order_id ..................................... [PASS in 11.42s]
01:32:41  11 of 31 START test unique_stg_orders_order_id ................................. [RUN]
01:32:53  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:32:54  11 of 31 PASS unique_stg_orders_order_id ....................................... [PASS in 13.24s]
01:32:54  12 of 31 START test accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card  [RUN]
01:33:06  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:33:07  12 of 31 PASS accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card  [PASS in 12.30s]
01:33:07  13 of 31 START test not_null_stg_payments_payment_id ........................... [RUN]
01:33:17  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:33:18  13 of 31 PASS not_null_stg_payments_payment_id ................................. [PASS in 11.02s]
01:33:18  14 of 31 START test unique_stg_payments_payment_id ............................. [RUN]
01:33:28  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:33:29  14 of 31 PASS unique_stg_payments_payment_id ................................... [PASS in 11.31s]
01:33:29  15 of 31 START sql table model jaffle_shop.customer_orders ..................... [RUN]
01:33:39  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:33:43  15 of 31 OK created sql table model jaffle_shop.customer_orders ................ [activity: Insert, rows_affected: 62 in 13.88s]
01:33:43  16 of 31 START sql table model jaffle_shop.customer_payments ................... [RUN]
01:33:53  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:33:57  16 of 31 OK created sql table model jaffle_shop.customer_payments .............. [activity: Insert, rows_affected: 62 in 13.86s]
01:33:57  17 of 31 START sql table model jaffle_shop.order_payments ...................... [RUN]
01:34:07  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:34:11  17 of 31 OK created sql table model jaffle_shop.order_payments ................. [activity: Insert, rows_affected: 99 in 13.94s]
01:34:11  18 of 31 START sql table model jaffle_shop.dim_customers ....................... [RUN]
01:34:21  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:34:24  18 of 31 OK created sql table model jaffle_shop.dim_customers .................. [activity: Insert, rows_affected: 100 in 13.70s]
01:34:24  19 of 31 START sql table model jaffle_shop.fct_orders .......................... [RUN]
01:34:34  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:34:38  19 of 31 OK created sql table model jaffle_shop.fct_orders ..................... [activity: Insert, rows_affected: 99 in 13.30s]
01:34:38  20 of 31 START test not_null_dim_customers_customer_id ......................... [RUN]
01:34:48  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:34:49  20 of 31 PASS not_null_dim_customers_customer_id ............................... [PASS in 11.60s]
01:34:49  21 of 31 START test unique_dim_customers_customer_id ........................... [RUN]
01:34:59  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:35:00  21 of 31 PASS unique_dim_customers_customer_id ................................. [PASS in 10.64s]
01:35:00  22 of 31 START test accepted_values_fct_orders_status__placed__shipped__completed__return_pending__returned  [RUN]
01:35:11  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:35:12  22 of 31 PASS accepted_values_fct_orders_status__placed__shipped__completed__return_pending__returned  [PASS in 11.69s]
01:35:12  23 of 31 START test not_null_fct_orders_amount ................................. [RUN]
01:35:22  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:35:23  23 of 31 PASS not_null_fct_orders_amount ....................................... [PASS in 10.92s]
01:35:23  24 of 31 START test not_null_fct_orders_bank_transfer_amount ................... [RUN]
01:35:33  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:35:34  24 of 31 PASS not_null_fct_orders_bank_transfer_amount ......................... [PASS in 11.00s]
01:35:34  25 of 31 START test not_null_fct_orders_coupon_amount .......................... [RUN]
01:35:43  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:35:45  25 of 31 PASS not_null_fct_orders_coupon_amount ................................ [PASS in 11.02s]
01:35:45  26 of 31 START test not_null_fct_orders_credit_card_amount ..................... [RUN]
01:35:55  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:35:56  26 of 31 PASS not_null_fct_orders_credit_card_amount ........................... [PASS in 11.74s]
01:35:56  27 of 31 START test not_null_fct_orders_customer_id ............................ [RUN]
01:36:06  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:36:07  27 of 31 PASS not_null_fct_orders_customer_id .................................. [PASS in 10.74s]
01:36:07  28 of 31 START test not_null_fct_orders_gift_card_amount ....................... [RUN]
01:36:17  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:36:18  28 of 31 PASS not_null_fct_orders_gift_card_amount ............................. [PASS in 11.03s]
01:36:18  29 of 31 START test not_null_fct_orders_order_id ............................... [RUN]
01:36:28  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:36:29  29 of 31 PASS not_null_fct_orders_order_id ..................................... [PASS in 11.12s]
01:36:29  30 of 31 START test relationships_fct_orders_customer_id__customer_id__ref_dim_customers_  [RUN]
01:36:39  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:36:40  30 of 31 PASS relationships_fct_orders_customer_id__customer_id__ref_dim_customers_  [PASS in 10.93s]
01:36:40  31 of 31 START test unique_fct_orders_order_id ................................. [RUN]
01:36:50  teradata adapter: Query Band set to ['=S> org=teradata-internal-telem;appname=dbt;']
01:36:51  31 of 31 PASS unique_fct_orders_order_id ....................................... [PASS in 10.86s]
01:36:51  
01:36:51  Finished running 3 seeds, 3 view models, 20 data tests, 5 table models in 0 hours 7 minutes and 3.10 seconds (423.10s).
01:36:51  
01:36:51  Completed successfully
01:36:51
01:36:51  Done. PASS=31 WARN=0 ERROR=0 SKIP=0 TOTAL=31
```

***Limitation***

**For the initial BROWSER authentication, the browser opens as expected, asking for the credentials. However, for every subsequent connection, a new browser tab opens, displaying the message 'TERADATA BROWSER AUTHENTICATION COMPLETED,' despite using an existing BROWSER session silently. This is the default behavior of the teradatasql driver, and there is no way to avoid this at the present time.**