### PR TITLE
Removal of Python 3.8 and document change for release

### DIFF
--- a/.github/workflows/ci-pre-release-test-testpypi-Linux.yml
+++ b/.github/workflows/ci-pre-release-test-testpypi-Linux.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
-        python: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python: [ '3.9', '3.10', '3.11', '3.12' ]
     runs-on: ubuntu-latest
     name: CI Pre Release Test TestPyPi
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
 ## dbt-teradata 1.0.0a
 
 ### Features
+* Addition of md5_udf variable for custom hash macro configuration
+  * (https://github.com/Teradata/dbt-teradata-utils/issues/2)
+* Full support for valid_history incremental strategy
+* Remove support and testing for Python 3.8, which is now EOL
 
 ### Fixes
+* adapter does not resolve dates correctly in unit testing 
+  * (https://teradata-pe.atlassian.net/browse/IDE-24644)
+* Snapshots fail on structure changes
+  * (https://github.com/Teradata/dbt-teradata/issues/192)
 
 ### Docs
+Updated Readme for 
+* md5_udf variable - for custom hash macro configuration
+* valid_history incremental strategy
+* unit testing support
 
 ### Under the hood
+* Test project for valid_history incremental strategy
+* Addition of more function tests for better coverage
+* Change in workflow file for testing md5_udf variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * Remove support and testing for Python 3.8, which is now EOL
 
 ### Fixes
-* adapter does not resolve dates correctly in unit testing 
-  * (https://teradata-pe.atlassian.net/browse/IDE-24644)
+* Adapter does not resolve dates correctly in unit testing
 * Snapshots fail on structure changes
   * (https://github.com/Teradata/dbt-teradata/issues/192)
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ At a minimum, you need to specify `host`, `user`, `password`, `schema` (database
 
 The logon mechanism for Teradata jobs that dbt executes can be configured with the `logmech` configuration in your Teradata profile. The `logmech` field can be set to: `TD2`, `LDAP`, `BROWSER`, `KRB5`, `TDNEGO`. For more information on authentication options, go to [Teradata Vantage authentication documentation](https://docs.teradata.com/r/8Mw0Cvnkhv1mk1LEFcFLpw/0Ev5SyB6_7ZVHywTP7rHkQ).
 
-> For the initial BROWSER authentication, the browser opens as expected, asking for the credentials. However, for every subsequent connection, a new browser tab opens, displaying the message 'TERADATA BROWSER AUTHENTICATION COMPLETED,' despite using an existing BROWSER session silently. This is the default behavior of the teradatasql driver, and there is no way to avoid this at the present time.
-
+> When running a dbt job with logmech set to "browser", the initial authentication opens a browser window where you must enter your username and password.<br>
+After authentication, this window remains open, requiring you to manually switch back to the dbt console.<br>
+For every subsequent connection, a new browser tab briefly opens, displaying the message "TERADATA BROWSER AUTHENTICATION COMPLETED," and silently reuses the existing session.<br>
+However, the focus stays on the browser window, so you’ll need to manually switch back to the dbt console each time.<br>
+This behavior is the default functionality of the teradatasql driver and cannot be avoided at this time.<br>
+To prevent session expiration and the need to re-enter credentials, ensure the authentication browser window stays open until the job is complete.
 
 ```yaml
 my-teradata-db-profile:
@@ -772,10 +776,16 @@ If no query_band is set by user, default query_band will come in play that is :
 ```org=teradata-internal-telem;appname=dbt;```
 
 ## Unit Testing
-Unit testing is supported in dbt-teradata. User can write unit tests in dbt and run them using dbt test command. For more information on unit testing in dbt, please refer to [dbt documentation](https://docs.getdbt.com/docs/build/unit-tests).<br>
-Unit tests for views require qvci to be enabled in the database. Please refer to the [General](#general) section for more information on enabling qvci.<br>
-Unit tests support for views will be limited if qvci is not enabled. User might see the below database error in case of testing views without qvci enabled:<br>
-```[Teradata Database] [Error 3706] Syntax error: Data Type "N" does not match a Defined Type name.```
+* Unit testing is supported in dbt-teradata, allowing users to write and execute unit tests using the dbt test command.
+  * For detailed guidance, refer to the dbt documentation.
+
+* QVCI must be enabled in the database to run unit tests for views.
+  * Additional details on enabling QVCI can be found in the General section.
+  * Without QVCI enabled, unit test support for views will be limited.
+  * Users might encounter the following database error when testing views without QVCI enabled:
+    ```
+    * [Teradata Database] [Error 3706] Syntax error: Data Type "N" does not match a Defined Type name.
+    ```
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -45,20 +45,21 @@ At a minimum, you need to specify `host`, `user`, `password`, `schema` (database
 
 ## Python compatibility
 
-| Plugin version | Python 3.6  | Python 3.7  | Python 3.8  | Python 3.9  | Python 3.10 | Python 3.11 | Python 3.12 |
-|----------------| ----------- | ----------- | ----------- | ----------- | ----------- |-------------|-------------|
-| 0.19.0.x       | ✅          | ✅          | ✅          | ❌          | ❌          | ❌           | ❌ 
-| 0.20.0.x       | ✅          | ✅          | ✅          | ✅          | ❌          | ❌           | ❌ 
-| 0.21.1.x       | ✅          | ✅          | ✅          | ✅          | ❌          | ❌           | ❌ 
-| 1.0.0.x        | ❌           | ✅          | ✅          | ✅          | ❌          | ❌          | ❌   
-| 1.1.x.x        | ❌           | ✅          | ✅          | ✅          | ✅          | ❌          | ❌ 
-| 1.2.x.x        | ❌           | ✅          | ✅          | ✅          | ✅          | ❌          | ❌  
-| 1.3.x.x        | ❌           | ✅          | ✅          | ✅          | ✅          | ❌          | ❌
-| 1.4.x.x        | ❌           | ✅          | ✅          | ✅          | ✅          | ✅          | ❌ 
-| 1.5.x          | ❌           | ✅          | ✅          | ✅          | ✅          | ✅          | ❌ 
-| 1.6.x          | ❌           | ❌          | ✅          | ✅          | ✅          | ✅          | ❌ 
-| 1.7.x          | ❌           | ❌          | ✅          | ✅          | ✅          | ✅          | ❌ 
-| 1.8.x          | ❌           | ❌          | ✅          | ✅          | ✅          | ✅          | ✅ 
+| Plugin version | Python 3.6  | Python 3.7  | Python 3.8 | Python 3.9  | Python 3.10 | Python 3.11 | Python 3.12 |
+|----------------| ----------- | ----------- | --------- | ----------- | ----------- |-------------|-------------|
+| 0.19.0.x       | ✅          | ✅          | ✅         | ❌          | ❌          | ❌           | ❌ 
+| 0.20.0.x       | ✅          | ✅          | ✅         | ✅          | ❌          | ❌           | ❌ 
+| 0.21.1.x       | ✅          | ✅          | ✅         | ✅          | ❌          | ❌           | ❌ 
+| 1.0.0.x        | ❌           | ✅          | ✅         | ✅          | ❌          | ❌          | ❌   
+| 1.1.x.x        | ❌           | ✅          | ✅         | ✅          | ✅          | ❌          | ❌ 
+| 1.2.x.x        | ❌           | ✅          | ✅         | ✅          | ✅          | ❌          | ❌  
+| 1.3.x.x        | ❌           | ✅          | ✅         | ✅          | ✅          | ❌          | ❌
+| 1.4.x.x        | ❌           | ✅          | ✅         | ✅          | ✅          | ✅          | ❌ 
+| 1.5.x          | ❌           | ✅          | ✅         | ✅          | ✅          | ✅          | ❌ 
+| 1.6.x          | ❌           | ❌          | ✅         | ✅          | ✅          | ✅          | ❌ 
+| 1.7.x          | ❌           | ❌          | ✅         | ✅          | ✅          | ✅          | ❌ 
+| 1.8.x          | ❌           | ❌          | ✅         | ✅          | ✅          | ✅          | ✅ 
+| 1.8.2          | ❌           | ❌          | ❌         | ✅          | ✅          | ✅          | ✅
 
 
 ##  dbt dependent packages version compatibility
@@ -694,6 +695,13 @@ If not specified the code defaults to using `GLOBAL_FUNCTIONS.hash_md5`. See bel
     ```sql
     GRANT EXECUTE FUNCTION ON GLOBAL_FUNCTIONS TO PUBLIC WITH GRANT OPTION;
     ```
+   
+Instruction on how to add md5_udf variable in dbt_project.yml for custom hash function:
+```yaml
+vars:
+  md5_udf: Custom_database_name.hash_method_function
+```
+
 #### <a name="last_day"></a>last_day
 
 `last_day` in `teradata_utils`, unlike the corresponding macro in `dbt_utils`, doesn't support `quarter` datepart.
@@ -762,6 +770,12 @@ Let model that user is running be stg_orders
 
 If no query_band is set by user, default query_band will come in play that is :
 ```org=teradata-internal-telem;appname=dbt;```
+
+## Unit Testing
+Unit testing is supported in dbt-teradata. User can write unit tests in dbt and run them using dbt test command. For more information on unit testing in dbt, please refer to [dbt documentation](https://docs.getdbt.com/docs/build/unit-tests).<br>
+Unit tests for views require qvci to be enabled in the database. Please refer to the [General](#general) section for more information on enabling qvci.<br>
+Unit tests support for views will be limited if qvci is not enabled. User might see the below database error in case of testing views without qvci enabled:<br>
+```[Teradata Database] [Error 3706] Syntax error: Data Type "N" does not match a Defined Type name.```
 
 
 ## Credits

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ pytest~=7.0
 tox~=3.2
 pylava~=0.3.0
 teradatasql>=20.00.00.10
-dbt-adapters>=1.2.1
+dbt-adapters>=1.7.2
 dbt-common>=1.3.0
 MarkupSafe==2.0.1
 pytest-dotenv

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ import sys
 from setuptools import setup
 
 
-if sys.version_info < (3, 8) or sys.version_info >= (3, 13):
+if sys.version_info < (3, 9) or sys.version_info >= (3, 13):
     print('Error: dbt-teradata does not support this version of Python.')
-    print('Please install Python 3.8 or higher but less than 3.13.')
+    print('Please install Python 3.9 or higher but less than 3.13.')
     sys.exit(1)
 
 
@@ -59,11 +59,10 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
 
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],
-    python_requires=">=3.8,<3.13",
+    python_requires=">=3.9,<3.13",
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ],
     },
     install_requires=[
-        "dbt-adapters>=1.2.1",
+        "dbt-adapters>=1.7.2",
         "dbt-common>=1.3.0",
         "teradatasql>=20.00.00.10",
     ],


### PR DESCRIPTION
### Description

This PR includes the removal of Python 3.8 as it is at EOL
Also documentation changes for 1.8.2 release


### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
