### PR TITLE
fallback_schema support

### DIFF
--- a/dbt/include/teradata/macros/catalog.sql
+++ b/dbt/include/teradata/macros/catalog.sql
@@ -1,3 +1,10 @@
+{% macro teradata_get_current_timestamp() %}
+    {%- call statement('current_timestamp', fetch_result=True) -%}
+        select cast(current_timestamp(0) as timestamp(0));
+    {% endcall %}
+    {{ return(load_result('current_timestamp').table.columns['Current TimeStamp(0)'].values()[0] | trim) }}
+{% endmacro %}
+
 {% macro teradata__get_views_from_relations(relations) -%}
     {% set view_relations = [] %}
     {%- for relation in relations -%}
@@ -15,30 +22,42 @@
 {%- endmacro %}
 
 {% macro teradata__create_tmp_tables_of_views(view_relations) -%}
+
+    {% set fallback_schema = var("fallback_schema", null) %}
+    {{ log("fallback_schema set to : " ~ fallback_schema) }}
+
     {% set view_tmp_tables_mapping = {} %}
     {%- for relation in view_relations -%}
-        {% set temp_relation_for_view = relation.identifier ~ '_tmp_viw_tbl' %}
+        {% set timestamp = teradata_get_current_timestamp() %}
+        {% set rand = range(1, 100000) | random %}
+        {% set uuid = timestamp.replace(":", "").replace("-", "").replace(" ","").replace("+","").replace(".","") ~ rand %}
+        {% set temp_relation_for_view = relation.identifier ~ '_tmp_viw_tbl_' ~ uuid %}
         {% set view_tmp_tables_mapping = view_tmp_tables_mapping.update({relation: temp_relation_for_view}) %}
     {%- endfor %}
 
-    {{ teradata__drop_tmp_tables_of_views(view_tmp_tables_mapping) }}
 
     {%- for relation, temp_relation_for_view in view_tmp_tables_mapping.items() %}
+        {% if fallback_schema==null %}
+          {% set schema_name = relation.schema %}
+        {% else %}
+          {% set schema_name = fallback_schema %}
+        {% endif %}
+
+        {{ teradata__drop_tmp_tables_of_views(schema_name, temp_relation_for_view) }}
+
         {% call statement('creating_table_from_view', fetch_result=False) %}
-            CREATE TABLE "{{ relation.schema }}"."{{ temp_relation_for_view }}" AS (SELECT * FROM "{{ relation.schema }}"."{{ relation.identifier }}") WITH NO DATA;
+            CREATE TABLE "{{ schema_name }}"."{{ temp_relation_for_view }}" AS (SELECT * FROM "{{ relation.schema }}"."{{ relation.identifier }}") WITH NO DATA;
         {% endcall %}
         load_result('creating_table_from_view')
     {%- endfor %}
     {{ return(view_tmp_tables_mapping) }}
 {%- endmacro %}
 
-{% macro teradata__drop_tmp_tables_of_views(view_tmp_tables_mapping) -%}
-    {% for relation, temp_table in view_tmp_tables_mapping.items() %}
-        {% call statement('drop_existing_table', fetch_result=False) %}
-            DROP table /*+ IF EXISTS */ "{{ relation.schema }}"."{{ temp_table }}";
-        {% endcall %}
-        load_result('drop_existing_table')
-    {% endfor %}
+{% macro teradata__drop_tmp_tables_of_views(schema_name, temp_relation_for_view) -%}
+    {% call statement('drop_existing_table', fetch_result=False) %}
+        DROP table /*+ IF EXISTS */ "{{ schema_name }}"."{{ temp_relation_for_view }}";
+    {% endcall %}
+    load_result('drop_existing_table')
 {%- endmacro %}
 
 
@@ -93,7 +112,15 @@
 
     {% set catalog_table = load_result('catalog').table %}
 
-    {{ teradata__drop_tmp_tables_of_views(view_tmp_tables_mapping) }}
+    {% set fallback_schema = var("fallback_schema", null) %}
+     {%- for relation, temp_relation_for_view in view_tmp_tables_mapping.items() %}
+        {% if fallback_schema==null %}
+          {% set schema_name = relation.schema %}
+        {% else %}
+          {% set schema_name = fallback_schema %}
+        {% endif %}
+        {{ teradata__drop_tmp_tables_of_views(schema_name, temp_relation_for_view) }}
+     {%- endfor %}
 
     {{ return(catalog_table) }}
 {%- endmacro %}
@@ -194,8 +221,13 @@
     joined AS (
       SELECT
           columns_transformed.table_database,
-          columns_transformed.table_schema,
           {% if view_tmp_tables_mapping is not none and view_tmp_tables_mapping|length > 0 %}
+            CASE
+              {% for relation, temp_table in view_tmp_tables_mapping.items() %}
+                WHEN columns_transformed.table_schema = upper('{{ var("fallback_schema", null) }}') THEN '{{ relation.schema }}'
+              {% endfor %}
+              ELSE columns_transformed.table_schema
+            END as table_schema,
             CASE
             {% for relation, temp_table in view_tmp_tables_mapping.items() %}
                 WHEN columns_transformed.table_name = '{{ temp_table }}' THEN '{{ relation.identifier }}'
@@ -259,15 +291,23 @@
         {%- for relation in relations -%}
             {% if relation.schema and relation.identifier %}
                 (
-                    upper("table_schema") = upper('{{ relation.schema }}')
                     {% if view_tmp_tables_mapping is not none and view_tmp_tables_mapping|length > 0 %}
+
                         {% set temp_table = view_tmp_tables_mapping[relation] %}
                         {% if not temp_table %}
+                            upper("table_schema") = upper('{{ relation.schema }}')
                             and upper("table_name") = upper('{{ relation.identifier }}')
                         {% else %}
-                            and upper("table_name") = upper('{{ temp_table }}')
+                            {% if var("fallback_schema", null) != null %}
+                                upper("table_schema") = upper('{{ var("fallback_schema", null) }}')
+                                and upper("table_name") = upper('{{ temp_table }}')
+                            {% else %}
+                                upper("table_schema") = upper('{{ relation.schema }}')
+                                and upper("table_name") = upper('{{ temp_table }}')
+                            {% endif %}
                         {% endif %}
                     {% else %}
+                        upper("table_schema") = upper('{{ relation.schema }}')
                         and upper("table_name") = upper('{{ relation.identifier }}')
                     {% endif %}
                 )

--- a/tests/functional/adapter/teradata_dbt/test_fallback_schema.py
+++ b/tests/functional/adapter/teradata_dbt/test_fallback_schema.py
@@ -1,0 +1,61 @@
+import pytest
+from dbt.tests.util import run_dbt, check_result_nodes_by_name
+import uuid
+
+from tests.functional.adapter.teradata_dbt.teradata_fixtures import(
+    test_table_csv,
+    table_from_source_for_catalog_test_sql,
+    view_from_source_for_catalog_test_sql,
+    sources_yml
+)
+
+
+
+class Test_fallback_schema:
+
+    @pytest.fixture(scope="class")
+    def random_db_name(self):
+        return f"tests_{uuid.uuid4().hex[:8]}"
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, random_db_name):
+        return {
+            "name": "test_fallback_schema",
+            "vars": {
+                    "fallback_schema": random_db_name
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "test_table.csv": test_table_csv
+        }
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_from_source_for_catalog_test.sql": table_from_source_for_catalog_test_sql,
+            "view_from_source_for_catalog_test.sql": view_from_source_for_catalog_test_sql,
+            "sources.yml": sources_yml
+        }
+
+
+    def test_fallback_schema(self, project, random_db_name):
+
+        project.run_sql(f"create database {random_db_name} as perm=100000;")
+
+        result1 = run_dbt(["seed"])
+        assert len(result1) == 1
+
+        result2 = run_dbt(["run"])
+        assert len(result2) == 2
+
+        check_result_nodes_by_name(result2, ["table_from_source_for_catalog_test", "view_from_source_for_catalog_test"])
+
+        catalog = run_dbt(["docs", "generate"])
+        # assert len(catalog.nodes) == 3
+        assert len(catalog.sources) == 1
+
+        project.run_sql(f"delete database {random_db_name};")
+        project.run_sql(f"drop database {random_db_name};")


### PR DESCRIPTION
resolves #212 
resolves #213 

### Description
This PR adds support for fallback_schema
Fallback_schema will be used by users if they do not have write permissions on the regular schema, they have models and all.
Fallback_schema helps in creating temporary tables during fetching of metadata of the views from the database, that too when the use_qvci variable is false

The user can add the fallback_schema same way they would add use_qvci in dbt_project.yml
e.g:

```
vars:
  fallback_schema: <schema_name>
```


### Checklist
 - [ ] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
