### PR TITLE
Changed how hashing function is applied to scd_id_expr

### DIFF
--- a/dbt/include/teradata/macros/materializations/snapshot/strategies.sql
+++ b/dbt/include/teradata/macros/materializations/snapshot/strategies.sql
@@ -1,6 +1,9 @@
 
 {% macro teradata__snapshot_hash_arguments(args) -%}
-    HASHROW({%- for arg in args -%}
+
+    {% set hashing_function = config.get('snapshot_hash_udf', 'HASHROW') %}
+    
+    {{ hashing_function }}({%- for arg in args -%}
         coalesce(cast({{ arg }} as varchar(50)), '')
         {% if not loop.last %} || '|' || {% endif %}
     {%- endfor -%})
@@ -82,11 +85,6 @@
 
     {% set scd_args = api.Relation.scd_args(primary_key, updated_at) %}
     {% set scd_id_expr = snapshot_hash_arguments(scd_args) %}
-    {% set snapshot_hash_udf = config.get('snapshot_hash_udf') %}
-    {% if snapshot_hash_udf is not none %}
-        {% set scd_id_expr = scd_id_expr |replace("HASHROW",snapshot_hash_udf) %}
-    {% endif %}
-
 
     {% do return({
         "unique_key": primary_key,


### PR DESCRIPTION
resolves #222 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description

Changed how hashing function is applied to snapshot_hash_arguments macro. This change should apply UDF hashing functions properly to scd_id calculation when using timestamp or check strategy.

Previously timestamp strategy ignored what was set in config block's snapshot_hash_udf variable.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [ ] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
