### PR TITLE
changes to support snapshot_hash_udf config for timestamp strategy

### DIFF
--- a/dbt/include/teradata/macros/materializations/snapshot/strategies.sql
+++ b/dbt/include/teradata/macros/materializations/snapshot/strategies.sql
@@ -1,6 +1,9 @@
 
 {% macro teradata__snapshot_hash_arguments(args) -%}
-    HASHROW({%- for arg in args -%}
+
+    {% set hashing_function = config.get('snapshot_hash_udf', 'HASHROW') %}
+    
+    {{ hashing_function }}({%- for arg in args -%}
         coalesce(cast({{ arg }} as varchar(50)), '')
         {% if not loop.last %} || '|' || {% endif %}
     {%- endfor -%})
@@ -82,11 +85,6 @@
 
     {% set scd_args = api.Relation.scd_args(primary_key, updated_at) %}
     {% set scd_id_expr = snapshot_hash_arguments(scd_args) %}
-    {% set snapshot_hash_udf = config.get('snapshot_hash_udf') %}
-    {% if snapshot_hash_udf is not none %}
-        {% set scd_id_expr = scd_id_expr |replace("HASHROW",snapshot_hash_udf) %}
-    {% endif %}
-
 
     {% do return({
         "unique_key": primary_key,


### PR DESCRIPTION
resolves #222

### Description

Changes on how Hashing function is applied to scd_id_expr as it was not being employed for timestamp strategy

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
