### PR TITLE
IDE-25271 fix: right truncation while hashing in snapshots

### DIFF
--- a/dbt/include/teradata/macros/materializations/snapshot/strategies.sql
+++ b/dbt/include/teradata/macros/materializations/snapshot/strategies.sql
@@ -4,7 +4,7 @@
     {% set hashing_function = config.get('snapshot_hash_udf', 'HASHROW') %}
     
     {{ hashing_function }}({%- for arg in args -%}
-        coalesce(cast({{ arg }} as varchar(50)), '')
+        coalesce(cast({{ arg }} as varchar(500)), '')
         {% if not loop.last %} || '|' || {% endif %}
     {%- endfor -%})
 {%- endmacro %}

--- a/tests/functional/adapter/test_snapshot_hash_udf.py
+++ b/tests/functional/adapter/test_snapshot_hash_udf.py
@@ -124,3 +124,55 @@ class Test_snapshot_hash_udf_timestamp:
         run_dbt(["--log-path", "log_output","snapshot"])
         log_output = read_file("log_output", "dbt.log").replace("\n", " ").replace("\\n", " ")
         assert "GLOBAL_FUNCTIONS.hash_md5" in log_output
+
+
+# Snapshot using long string as unique_key to test varchar truncation fix
+snapshot_varchar_truncation_sql = """
+{% snapshot snapshot_varchar_truncation %}
+    {{ config(
+        unique_key='long_description',
+        strategy='check',
+        check_cols=['name'],
+        target_database=database,
+        target_schema=schema,
+        snapshot_hash_udf='GLOBAL_FUNCTIONS.hash_md5'
+    ) }}
+    select * from {{ ref(var('seed_name', 'long_string_data')) }}
+{% endsnapshot %}
+""".strip()
+
+# Test data with long strings that exceed varchar(50) limit
+seeds_long_string_data_csv = """
+id,name,long_description
+1,John Smith,"This is an extremely long description that definitely exceeds the fifty character limit that was causing varchar truncation errors in snapshot hash functions before the fix was applied"
+2,Jane Doe,"Another extraordinarily long description that goes well beyond the fifty character limitation that was imposed by the previous snapshot hash implementation and should now work properly"
+3,Bob Johnson,"Yet another lengthy description that would have caused issues when the snapshot tried to hash this content using the old varchar fifty character limitation but should now work fine"
+""".lstrip()
+
+
+class Test_snapshot_hash_udf_varchar_truncation:
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "test_snapshot_hash_udf_varchar_truncation"
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "long_string_data.csv": seeds_long_string_data_csv
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {
+            "snapshot_varchar_truncation.sql": snapshot_varchar_truncation_sql
+        }
+
+    def test_snapshot_hash_udf_varchar_truncation(self, project):
+        (pathlib.Path(project.project_root) / "log_output").mkdir(parents=True, exist_ok=True)
+        run_dbt(["seed"])
+        run_dbt(["--log-path", "log_output","snapshot"])
+        log_output = read_file("log_output", "dbt.log").replace("\n", " ").replace("\\n", " ")
+        assert "GLOBAL_FUNCTIONS.hash_md5" in log_output


### PR DESCRIPTION
resolves #229 

### Description

This PR resolves the right truncation issue for hashing in the snapshots as we increase the length during casting


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [] I have updated the `CHANGELOG.md` with information about my change
